### PR TITLE
Let the player climb ladders instead of sliding off them

### DIFF
--- a/.tools/bake_ladders.mjs
+++ b/.tools/bake_ladders.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Bake climbable ladder volumes out of the static collision glTF.
+ *
+ * The T6 dump carries no ladder surface flags or trigger volumes, so the only
+ * thing identifying a ladder at runtime is the prop's node name.  Each matching
+ * node becomes one upright box: a world centre, a horizontal `right` axis along
+ * the rungs, a horizontal `normal` axis out of the climbing face, and the Y
+ * span the player may climb through.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_INPUT = 'export/web/hijacked_collision.gltf';
+const DEFAULT_OUTPUT = 'export/web/hijacked_ladders.json';
+const DEFAULT_PATTERN = 'ladder';
+
+function absolute(filename) {
+  return path.isAbsolute(filename) ? filename : path.resolve(ROOT, filename);
+}
+
+function parseArgs(argv) {
+  const args = { input: DEFAULT_INPUT, output: DEFAULT_OUTPUT, pattern: DEFAULT_PATTERN };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--input' || arg === '-i') args.input = argv[++i];
+    else if (arg === '--output' || arg === '-o') args.output = argv[++i];
+    else if (arg === '--pattern' || arg === '-p') args.pattern = argv[++i];
+    else if (arg === '--help' || arg === '-h') {
+      console.log('usage: node .tools/bake_ladders.mjs [--input collision.gltf] [--output ladders.json] [--pattern ladder]');
+      return null;
+    } else throw new Error(`unknown argument ${arg}`);
+  }
+  return args;
+}
+
+// glTF matrices are column-major: element (row r, column c) lives at a[c * 4 + r].
+// Only a handful of operations are needed here, so they are spelled out rather
+// than pulling three.js into a build script the browser never runs.
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+function multiply(a, b) {
+  const out = new Array(16).fill(0);
+  for (let c = 0; c < 4; c += 1) {
+    for (let r = 0; r < 4; r += 1) {
+      let sum = 0;
+      for (let k = 0; k < 4; k += 1) sum += a[k * 4 + r] * b[c * 4 + k];
+      out[c * 4 + r] = sum;
+    }
+  }
+  return out;
+}
+
+function column(matrix, index) {
+  return [matrix[index * 4], matrix[index * 4 + 1], matrix[index * 4 + 2]];
+}
+
+function transformPoint(matrix, point) {
+  const [x, y, z] = point;
+  return [0, 1, 2].map((r) => (
+    matrix[r] * x + matrix[4 + r] * y + matrix[8 + r] * z + matrix[12 + r]
+  ));
+}
+
+function length(vector) {
+  return Math.hypot(vector[0], vector[1], vector[2]);
+}
+
+function fromQuaternion(translation, rotation, scale) {
+  const [x, y, z, w] = rotation;
+  const [sx, sy, sz] = scale;
+  return [
+    (1 - 2 * (y * y + z * z)) * sx, (2 * (x * y + z * w)) * sx, (2 * (x * z - y * w)) * sx, 0,
+    (2 * (x * y - z * w)) * sy, (1 - 2 * (x * x + z * z)) * sy, (2 * (y * z + x * w)) * sy, 0,
+    (2 * (x * z + y * w)) * sz, (2 * (y * z - x * w)) * sz, (1 - 2 * (x * x + y * y)) * sz, 0,
+    translation[0], translation[1], translation[2], 1,
+  ];
+}
+
+/** Local-space bounding box of a mesh, read from accessor min/max only. */
+function meshBounds(gltf, meshIndex) {
+  const mesh = gltf.meshes?.[meshIndex];
+  if (!mesh) return null;
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (const primitive of mesh.primitives ?? []) {
+    const accessor = gltf.accessors?.[primitive.attributes?.POSITION];
+    if (!accessor?.min || !accessor?.max) continue;
+    for (let i = 0; i < 3; i += 1) {
+      min[i] = Math.min(min[i], accessor.min[i]);
+      max[i] = Math.max(max[i], accessor.max[i]);
+    }
+  }
+  return Number.isFinite(min[0]) ? { min, max } : null;
+}
+
+function localMatrix(node) {
+  if (Array.isArray(node.matrix)) return node.matrix;
+  return fromQuaternion(
+    node.translation ?? [0, 0, 0],
+    node.rotation ?? [0, 0, 0, 1],
+    node.scale ?? [1, 1, 1],
+  );
+}
+
+/** Walk the default scene, yielding every node with its accumulated transform. */
+function* walkScene(gltf) {
+  const scene = gltf.scenes?.[gltf.scene ?? 0];
+  const stack = (scene?.nodes ?? []).map((index) => ({ index, parent: IDENTITY }));
+  while (stack.length > 0) {
+    const { index, parent } = stack.pop();
+    const node = gltf.nodes?.[index];
+    if (!node) continue;
+    const world = multiply(parent, localMatrix(node));
+    yield { index, node, world };
+    for (const child of node.children ?? []) stack.push({ index: child, parent: world });
+  }
+}
+
+/**
+ * Turn a node's local box plus its world matrix into an upright climb volume.
+ *
+ * The axis closest to world up is the climb direction; of the remaining two the
+ * wider one runs along the rungs and the thinner one is the face normal.
+ */
+function volumeFor(name, box, world) {
+  const axes = [];
+  for (let i = 0; i < 3; i += 1) {
+    const axis = column(world, i);
+    const scale = length(axis);
+    if (scale < 1e-8) return null;
+    axes.push({
+      axis: axis.map((component) => component / scale),
+      half: ((box.max[i] - box.min[i]) / 2) * scale,
+    });
+  }
+
+  const upIndex = axes
+    .map((entry, i) => ({ i, alignment: Math.abs(entry.axis[1]) }))
+    .sort((a, b) => b.alignment - a.alignment)[0].i;
+  const up = axes[upIndex];
+  if (Math.abs(up.axis[1]) < 0.9) return null; // a tilted ladder is not supported
+
+  const [width, depth] = axes.filter((_, i) => i !== upIndex).sort((a, b) => b.half - a.half);
+
+  const center = transformPoint(world, [0, 1, 2].map((i) => (box.min[i] + box.max[i]) / 2));
+  // Flatten the horizontal axes so the runtime never has to renormalise them.
+  const right = flatten(width.axis);
+  const normal = flatten(depth.axis);
+  if (!right || !normal) return null;
+
+  return {
+    name,
+    center: center.map(round),
+    right: right.map(round),
+    normal: normal.map(round),
+    halfWidth: round(width.half),
+    halfDepth: round(depth.half),
+    bottom: round(center[1] - up.half),
+    top: round(center[1] + up.half),
+  };
+}
+
+/** Drop the Y component and renormalise, or null if the axis was vertical. */
+function flatten(axis) {
+  const level = [axis[0], 0, axis[2]];
+  const size = length(level);
+  if (size < 1e-6) return null;
+  return level.map((component) => component / size);
+}
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args) return;
+  const input = absolute(args.input);
+  const output = absolute(args.output);
+  const gltf = JSON.parse(fs.readFileSync(input, 'utf8'));
+  const pattern = args.pattern.toLowerCase();
+
+  const volumes = [];
+  const skipped = [];
+  for (const { node, world } of walkScene(gltf)) {
+    const name = node.name ?? '';
+    if (!name.toLowerCase().includes(pattern)) continue;
+    if (node.mesh === undefined) continue;
+    const box = meshBounds(gltf, node.mesh);
+    if (!box) {
+      skipped.push(`${name}: mesh ${node.mesh} has no position bounds`);
+      continue;
+    }
+    const volume = volumeFor(name, box, world);
+    if (!volume) {
+      skipped.push(`${name}: not an upright box`);
+      continue;
+    }
+    volumes.push(volume);
+  }
+
+  volumes.sort((a, b) => a.center[0] - b.center[0] || a.center[2] - b.center[2]);
+  const metadata = {
+    format: 'hijacked-ladders-v1',
+    source: path.relative(ROOT, input).replaceAll('\\', '/'),
+    coordinateSystem: 'three-y-up',
+    pattern: args.pattern,
+    count: volumes.length,
+    volumes,
+  };
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(metadata, null, 2)}\n`);
+
+  for (const note of skipped) console.warn(`skipped ${note}`);
+  console.log(`found ${volumes.length} ladder volume(s) matching "${args.pattern}"`);
+  for (const volume of volumes) {
+    console.log(
+      `  ${volume.name} at ${volume.center.join(', ')} ` +
+        `rise ${round(volume.top - volume.bottom)} width ${round(volume.halfWidth * 2)}`,
+    );
+  }
+  console.log(`wrote ${path.relative(ROOT, output)}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(`error: ${error instanceof Error ? error.stack ?? error.message : error}`);
+  process.exitCode = 1;
+}

--- a/export/web/hijacked_ladders.json
+++ b/export/web/hijacked_ladders.json
@@ -1,0 +1,97 @@
+{
+  "format": "hijacked-ladders-v1",
+  "source": "export/web/hijacked_collision.gltf",
+  "coordinateSystem": "three-y-up",
+  "pattern": "ladder",
+  "count": 4,
+  "volumes": [
+    {
+      "name": "i_clt_ladder_construction_01",
+      "center": [
+        -1529.851,
+        26.458,
+        -330.874
+      ],
+      "right": [
+        0.645,
+        0,
+        -0.764
+      ],
+      "normal": [
+        0.764,
+        0,
+        0.645
+      ],
+      "halfWidth": 13.5,
+      "halfDepth": 2.5,
+      "bottom": -43.5,
+      "top": 96.415
+    },
+    {
+      "name": "i_clt_ladder_construction_01",
+      "center": [
+        -1241.696,
+        -106.542,
+        -188
+      ],
+      "right": [
+        0,
+        0,
+        1
+      ],
+      "normal": [
+        -1,
+        0,
+        0
+      ],
+      "halfWidth": 13.5,
+      "halfDepth": 2.5,
+      "bottom": -176.5,
+      "top": -36.585
+    },
+    {
+      "name": "i_clt_ladder_construction_01",
+      "center": [
+        866.696,
+        -44.542,
+        -281
+      ],
+      "right": [
+        0,
+        0,
+        -1
+      ],
+      "normal": [
+        1,
+        0,
+        0
+      ],
+      "halfWidth": 13.5,
+      "halfDepth": 2.5,
+      "bottom": -114.5,
+      "top": 25.415
+    },
+    {
+      "name": "i_clt_ladder_construction_01",
+      "center": [
+        1123.304,
+        89.958,
+        -278
+      ],
+      "right": [
+        0,
+        0,
+        1
+      ],
+      "normal": [
+        -1,
+        0,
+        0
+      ],
+      "halfWidth": 13.5,
+      "halfDepth": 2.5,
+      "bottom": 20,
+      "top": 159.915
+    }
+  ]
+}

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -1200,7 +1200,7 @@ async function start() {
         console.warn('Viewmodel unavailable:', error);
       })
       .finally(() => frontend.stage('viewmodel'));
-    const [renderGltf, loadedCollisionWorld, hints] = await Promise.all([
+    const [renderGltf, loadedCollisionWorld, hints, ladders] = await Promise.all([
       loadGltf('hijacked_optimized.glb', 'map').then((gltf) => {
         // KTX2 texture decoding is complete when GLTFLoader resolves.
         frontend.stage('textures');
@@ -1211,6 +1211,15 @@ async function start() {
       fetch('hijacked_nav_hints.json').then((response) => {
         if (!response.ok) throw new Error(`nav hints HTTP ${response.status}`);
         return response.json();
+      }),
+      // Baked by `npm run bake:ladders`; the map export carries no ladder
+      // surface flags, so climbing needs these volumes.
+      fetch('hijacked_ladders.json').then((response) => {
+        if (!response.ok) throw new Error(`ladders HTTP ${response.status}`);
+        return response.json();
+      }).catch((error) => {
+        console.warn('Ladders unavailable:', error);
+        return null;
       }),
     ]);
     mapOptimization = optimizeStaticScene(renderGltf.scene);
@@ -1233,6 +1242,7 @@ async function start() {
       jumpHeight: 48,
       maxSlopeAngle: 45,
       fallResetY: -700,
+      ladders,
     });
     playerHealth = new PlayerHealth({
       maxHealth: 100,

--- a/export/web/player-controller.js
+++ b/export/web/player-controller.js
@@ -19,6 +19,7 @@ const _groundOrigin = new THREE.Vector3();
 const _groundRay = new THREE.Ray(new THREE.Vector3(), new THREE.Vector3(0, -1, 0));
 const _candidateStart = new THREE.Vector3();
 const _candidateEnd = new THREE.Vector3();
+const _ladderWish = new THREE.Vector3();
 
 function numberOr(value, fallback) {
   return Number.isFinite(value) ? value : fallback;
@@ -59,6 +60,46 @@ function copyPosition(value, fallback) {
     return new THREE.Vector3(value.x, value.y, value.z);
   }
   return fallback.clone();
+}
+
+function levelAxis(value, fallback) {
+  const axis = new THREE.Vector3(
+    Number(value?.[0] ?? value?.x) || 0,
+    0,
+    Number(value?.[2] ?? value?.z) || 0,
+  );
+  return axis.lengthSq() < 1e-8 ? fallback.clone() : axis.normalize();
+}
+
+/**
+ * Normalise one baked ladder descriptor into the form the controller uses.
+ *
+ * A ladder is an upright box: `right` runs along the rungs, `normal` points out
+ * of one climbing face, and both faces are climbable because the export carries
+ * no hint about which side is bolted to a wall.
+ */
+export function createLadderVolume(descriptor) {
+  if (!descriptor) return null;
+  const center = copyPosition(
+    Array.isArray(descriptor.center)
+      ? { x: descriptor.center[0], y: descriptor.center[1], z: descriptor.center[2] }
+      : descriptor.center,
+    new THREE.Vector3(),
+  );
+  const right = levelAxis(descriptor.right, new THREE.Vector3(1, 0, 0));
+  const normal = levelAxis(descriptor.normal, new THREE.Vector3(0, 0, 1));
+  const halfWidth = Math.max(0, numberOr(descriptor.halfWidth, 16));
+  const halfDepth = Math.max(0, numberOr(descriptor.halfDepth, 4));
+  const bottom = numberOr(descriptor.bottom, center.y - 64);
+  const top = numberOr(descriptor.top, center.y + 64);
+  if (!(top > bottom)) return null;
+  return { name: descriptor.name ?? 'ladder', center, right, normal, halfWidth, halfDepth, bottom, top };
+}
+
+/** Accepts a bare array of descriptors or the baked `{ volumes: [...] }` file. */
+export function createLadderVolumes(source) {
+  const list = Array.isArray(source) ? source : (source?.volumes ?? []);
+  return list.map(createLadderVolume).filter(Boolean);
 }
 
 /**
@@ -155,6 +196,23 @@ export class PlayerController {
     this.jumpBufferTime = Math.max(0, numberOr(options.jumpBufferTime, 0.12));
     this.fallResetY = Number.isFinite(options.fallResetY) ? options.fallResetY : null;
 
+    // Ladders are volumes rather than surfaces: the collision mesh only knows
+    // the prop is solid, so climbing is driven entirely by these boxes.
+    this.ladderClimbSpeed = Math.max(0, numberOr(options.ladderClimbSpeed, 180));
+    this.ladderGripSpeed = Math.max(0, numberOr(options.ladderGripSpeed, 120));
+    this.ladderReach = Math.max(0, numberOr(options.ladderReach, 12));
+    this.ladderPushSpeed = Math.max(0, numberOr(options.ladderPushSpeed, 220));
+    this.ladderExitSpeed = Math.max(0, numberOr(options.ladderExitSpeed, 220));
+    this.ladderTopClearance = Math.max(0, numberOr(options.ladderTopClearance, 4));
+    this.ladderExitTime = Math.max(0, numberOr(options.ladderExitTime, 0.3));
+    // A ladder bolted flat against geometry can be mounted from the wrong face.
+    // Rather than hang there weightless, let go once the climb stops making
+    // progress it was asked to make.
+    this.ladderStallTime = Math.max(0, numberOr(options.ladderStallTime, 0.4));
+    // How squarely the player must be pushing at a face before they mount it,
+    // so brushing past a ladder while strafing does not grab it.
+    this.ladderMountBias = clamp(numberOr(options.ladderMountBias, 0.25), 0, 1);
+
     this.velocity = new THREE.Vector3();
     this.collider = new Capsule(new THREE.Vector3(), new THREE.Vector3(), this.radius);
     this.input = {
@@ -167,6 +225,7 @@ export class PlayerController {
     this.onFloor = false;
     this.grounded = false;
     this.crouched = false;
+    this.onLadder = false;
     this.enabled = true;
     this._accumulator = 0;
     this._jumpBufferTimer = 0;
@@ -174,6 +233,11 @@ export class PlayerController {
     this._jumpHeld = false;
     this._collisionNormal = new THREE.Vector3(0, 1, 0);
     this._lastCollision = null;
+    this.ladders = createLadderVolumes(options.ladders);
+    this._ladder = null;
+    this._ladderSide = 1;
+    this._ladderExitTimer = 0;
+    this._ladderStall = 0;
 
     if (collisionSource && !sourceIsOctree) {
       this.buildCollision(collisionSource);
@@ -211,6 +275,17 @@ export class PlayerController {
   }
 
   /**
+   * Install climbable ladder volumes.  Accepts the baked ladder file, a bare
+   * array of descriptors, or already-normalised volumes.
+   */
+  setLadders(source) {
+    this.ladders = createLadderVolumes(source);
+    this._releaseLadder();
+    this._ladderExitTimer = 0;
+    return this;
+  }
+
+  /**
    * Change the respawn point.  By convention this is a feet position; pass
    * `{ eye: true }` when the supplied point is already a camera eye position.
    */
@@ -238,6 +313,8 @@ export class PlayerController {
     this.onFloor = false;
     this.grounded = false;
     this._lastCollision = null;
+    this._releaseLadder();
+    this._ladderExitTimer = 0;
 
     if (resolve && this.worldReady) this._resolveOverlaps();
     this._syncCamera();
@@ -289,6 +366,7 @@ export class PlayerController {
     if (!this.enabled) {
       this.velocity.set(0, 0, 0);
       this._accumulator = 0;
+      this._releaseLadder();
     }
     return this;
   }
@@ -336,8 +414,13 @@ export class PlayerController {
       velocity: this.velocity,
       grounded: this.onFloor,
       crouched: this.crouched,
+      onLadder: this.onLadder,
       worldReady: this.worldReady,
     };
+  }
+
+  get isOnLadder() {
+    return this.onLadder;
   }
 
   get position() {
@@ -379,8 +462,16 @@ export class PlayerController {
     this._jumpBufferTimer = Math.max(0, this._jumpBufferTimer - dt);
 
     this._updateCrouchState();
+    this._updateLadderState(dt);
 
-    if (this._jumpBufferTimer > 0 && (this.onFloor || this._coyoteTimer > 0)) {
+    // A jump always leaves the ladder, pushing back off the face so the player
+    // clears it instead of immediately re-grabbing.
+    if (this.onLadder && this._jumpBufferTimer > 0) {
+      this._detachLadder({ pushOff: this.ladderPushSpeed, hop: this.jumpSpeed * 0.6 });
+      this._jumpBufferTimer = 0;
+    }
+
+    if (!this.onLadder && this._jumpBufferTimer > 0 && (this.onFloor || this._coyoteTimer > 0)) {
       this.velocity.y = this.jumpSpeed;
       this.onFloor = false;
       this.grounded = false;
@@ -388,13 +479,17 @@ export class PlayerController {
       this._coyoteTimer = 0;
     }
 
-    this._updateHorizontalVelocity(dt);
-    if (this.onFloor) {
-      // A small downward bias keeps the capsule attached to gently uneven
-      // floors without allowing gravity to make it jitter through the mesh.
-      if (this.velocity.y <= 0) this.velocity.y = -this.groundSnapSpeed;
+    if (this.onLadder) {
+      this._updateLadderVelocity();
     } else {
-      this.velocity.y = Math.max(this.velocity.y - this.gravity * dt, -this.maxFallSpeed);
+      this._updateHorizontalVelocity(dt);
+      if (this.onFloor) {
+        // A small downward bias keeps the capsule attached to gently uneven
+        // floors without allowing gravity to make it jitter through the mesh.
+        if (this.velocity.y <= 0) this.velocity.y = -this.groundSnapSpeed;
+      } else {
+        this.velocity.y = Math.max(this.velocity.y - this.gravity * dt, -this.maxFallSpeed);
+      }
     }
 
     // Octree.capsuleIntersect is an overlap test rather than a swept test.
@@ -404,20 +499,32 @@ export class PlayerController {
     const moveSteps = Math.max(1, Math.ceil(travel / this.maxCollisionStep));
     const moveDt = dt / moveSteps;
     _movement.copy(this.velocity).multiplyScalar(moveDt);
+    const climbSpeedY = this.velocity.y;
+    const previousFeetY = this.collider.start.y - this.radius;
     let groundedDuringMove = false;
     for (let i = 0; i < moveSteps; i += 1) {
       this.collider.translate(_movement);
       this._resolveCollisions();
+      // Rung tops are walkable-facing triangles.  On a ladder they must not
+      // arrest the climb the way a floor would.
+      if (this.onLadder) this.velocity.y = climbSpeedY;
       groundedDuringMove = groundedDuringMove || this.onFloor;
     }
-    // Keep a floor contact found by an earlier movement slice even if the
-    // last slice only moved tangentially and generated no new overlap.
-    if (!groundedDuringMove && this.velocity.y <= this.maxGroundProbeRiseSpeed) {
-      groundedDuringMove = this._probeGround();
+
+    if (this.onLadder) {
+      this.onFloor = false;
+      this.grounded = false;
+      this._updateLadderExit(dt, previousFeetY);
+    } else {
+      // Keep a floor contact found by an earlier movement slice even if the
+      // last slice only moved tangentially and generated no new overlap.
+      if (!groundedDuringMove && this.velocity.y <= this.maxGroundProbeRiseSpeed) {
+        groundedDuringMove = this._probeGround();
+      }
+      this.onFloor = groundedDuringMove;
+      this.grounded = groundedDuringMove;
+      if (groundedDuringMove && this.velocity.y < 0) this.velocity.y = 0;
     }
-    this.onFloor = groundedDuringMove;
-    this.grounded = groundedDuringMove;
-    if (groundedDuringMove && this.velocity.y < 0) this.velocity.y = 0;
 
     if (this.fallResetY !== null && this.collider.start.y - this.radius < this.fallResetY) {
       this.reset(this.spawn, { eye: this.spawnIsEye, resolve: true });
@@ -425,19 +532,7 @@ export class PlayerController {
   }
 
   _updateHorizontalVelocity(dt) {
-    _wish.set(0, 0, 0);
-    _forward.set(0, 0, -1).applyQuaternion(this.camera.quaternion);
-    _forward.y = 0;
-    if (_forward.lengthSq() < 1e-8) _forward.set(0, 0, -1);
-    else _forward.normalize();
-    _right.crossVectors(_forward, this.camera.up);
-    _right.y = 0;
-    if (_right.lengthSq() < 1e-8) _right.set(1, 0, 0);
-    else _right.normalize();
-
-    _wish.addScaledVector(_forward, this.input.forward);
-    _wish.addScaledVector(_right, this.input.strafe);
-    if (_wish.lengthSq() > 1) _wish.normalize();
+    this._wishDirection(_wish);
 
     const speed = this.crouched
       ? this.crouchSpeed
@@ -461,6 +556,158 @@ export class PlayerController {
       this._setCapsuleHeight(this.height);
       this.crouched = false;
     }
+  }
+
+  /** Flat wish direction from the current input, in world space. */
+  _wishDirection(target) {
+    _forward.set(0, 0, -1).applyQuaternion(this.camera.quaternion);
+    _forward.y = 0;
+    if (_forward.lengthSq() < 1e-8) _forward.set(0, 0, -1);
+    else _forward.normalize();
+    _right.crossVectors(_forward, this.camera.up);
+    _right.y = 0;
+    if (_right.lengthSq() < 1e-8) _right.set(1, 0, 0);
+    else _right.normalize();
+
+    target.set(0, 0, 0);
+    target.addScaledVector(_forward, this.input.forward);
+    target.addScaledVector(_right, this.input.strafe);
+    if (target.lengthSq() > 1) target.normalize();
+    return target;
+  }
+
+  /**
+   * Where the capsule sits relative to a ladder, or null when out of reach.
+   *
+   * `across` is signed along the volume normal so `side` records which face the
+   * player is climbing; `along` is the offset across the rungs.
+   */
+  _ladderContact(ladder) {
+    if (!ladder) return null;
+    const feetY = this.collider.start.y - this.radius;
+    const headY = this.collider.end.y + this.radius;
+    // Reach above the rails so a climber clears the lip under _updateLadderExit
+    // rather than silently losing contact on the way up.
+    if (headY < ladder.bottom || feetY > ladder.top + this.ladderTopClearance * 2) return null;
+
+    const dx = this.collider.start.x - ladder.center.x;
+    const dz = this.collider.start.z - ladder.center.z;
+    const along = dx * ladder.right.x + dz * ladder.right.z;
+    if (Math.abs(along) > ladder.halfWidth + this.radius) return null;
+
+    const across = dx * ladder.normal.x + dz * ladder.normal.z;
+    const standoff = ladder.halfDepth + this.radius;
+    if (Math.abs(across) > standoff + this.ladderReach) return null;
+
+    return { along, across, standoff, feetY, side: across >= 0 ? 1 : -1 };
+  }
+
+  /** Attach to, or drop off, a ladder before this step's movement is built. */
+  _updateLadderState(dt) {
+    this._ladderExitTimer = Math.max(0, this._ladderExitTimer - dt);
+
+    if (this.onLadder) {
+      // Strafing off the end of the rungs, or climbing out of the volume,
+      // simply lets go.
+      if (!this._ladderContact(this._ladder)) this._detachLadder();
+      return;
+    }
+
+    if (this._ladderExitTimer > 0 || this.ladders.length === 0) return;
+
+    this._wishDirection(_ladderWish);
+    if (_ladderWish.lengthSq() < 1e-6) return;
+
+    for (const ladder of this.ladders) {
+      const contact = this._ladderContact(ladder);
+      if (!contact) continue;
+      // Nothing left to climb means this is a ledge to walk off, not a mount.
+      if (ladder.top - contact.feetY < this.ladderTopClearance) continue;
+      const into = -(_ladderWish.x * ladder.normal.x + _ladderWish.z * ladder.normal.z) * contact.side;
+      if (into < this.ladderMountBias) continue;
+      this.onLadder = true;
+      this._ladder = ladder;
+      this._ladderSide = contact.side;
+      return;
+    }
+  }
+
+  /**
+   * Drive the climb.  Velocity is set outright rather than accelerated so the
+   * ladder feels crisp, and because gravity is not integrated while attached.
+   */
+  _updateLadderVelocity() {
+    const ladder = this._ladder;
+    const side = this._ladderSide;
+    this._wishDirection(_ladderWish);
+
+    // Pushing at the face climbs, pulling away descends; sliding along the
+    // rungs is how the player steps off sideways.
+    const into = -(_ladderWish.x * ladder.normal.x + _ladderWish.z * ladder.normal.z) * side;
+    const along = _ladderWish.x * ladder.right.x + _ladderWish.z * ladder.right.z;
+    this.velocity.y = into * this.ladderClimbSpeed;
+
+    // Close any remaining gap to the face, but never push into it once in
+    // contact, which would fight the collision resolver and jitter the camera.
+    const contact = this._ladderContact(ladder);
+    const gap = contact ? Math.abs(contact.across) - contact.standoff : 0;
+    const grip = gap > 0 ? Math.min(gap / this.fixedTimeStep, this.ladderGripSpeed) : 0;
+
+    const strafe = along * this.ladderClimbSpeed * 0.5;
+    this.velocity.x = ladder.right.x * strafe - ladder.normal.x * side * grip;
+    this.velocity.z = ladder.right.z * strafe - ladder.normal.z * side * grip;
+  }
+
+  /** Leave the ladder once the player tops out, lands, or stops making headway. */
+  _updateLadderExit(dt, previousFeetY) {
+    const ladder = this._ladder;
+    const feetY = this.collider.start.y - this.radius;
+
+    // Geometry the volume knows nothing about — the wall behind a ladder, an
+    // overhang at the top — can pin a climb in place.  Treat sustained failure
+    // to move as a signal to let go.
+    const wanted = Math.abs(this.velocity.y) * dt;
+    if (wanted > 1e-4 && Math.abs(feetY - previousFeetY) < wanted * 0.25) {
+      this._ladderStall += dt;
+      if (this._ladderStall >= this.ladderStallTime) {
+        this._detachLadder();
+        return;
+      }
+    } else {
+      this._ladderStall = 0;
+    }
+
+    if (this.velocity.y > 0 && feetY >= ladder.top + this.ladderTopClearance) {
+      // Step over the lip away from the climbing face, where the surface the
+      // ladder serves has to be, and let gravity settle the landing.
+      this._detachLadder({ pushOff: -this.ladderExitSpeed });
+      return;
+    }
+    // Let go once there is floor underfoot.  The rails usually stop a little
+    // above the ground, and the capsule rests a skin width clear of it, so an
+    // exact `feetY <= bottom` test would strand the player on the last rung.
+    if (this.velocity.y < 0 && (feetY <= ladder.bottom || this._probeGround())) {
+      this._detachLadder();
+    }
+  }
+
+  /** Detach, optionally shoving the player off the face. */
+  _detachLadder({ pushOff = 0, hop = 0 } = {}) {
+    const ladder = this._ladder;
+    const side = this._ladderSide;
+    this._releaseLadder();
+    this._ladderExitTimer = this.ladderExitTime;
+    if (ladder && pushOff !== 0) {
+      this.velocity.x = ladder.normal.x * side * pushOff;
+      this.velocity.z = ladder.normal.z * side * pushOff;
+    }
+    if (hop !== 0) this.velocity.y = hop;
+  }
+
+  _releaseLadder() {
+    this.onLadder = false;
+    this._ladder = null;
+    this._ladderStall = 0;
   }
 
   _setCapsuleHeight(height) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ai:record": "node .tools/ai-game.mjs record",
     "bake:map": "node .tools/bake_map.mjs",
     "bake:collision": "node .tools/bake_collision_bvh.mjs",
+    "bake:ladders": "node .tools/bake_ladders.mjs",
     "bake:navmesh": "node .tools/bake_navmesh.mjs",
     "bake:env": "node .tools/bake_env.mjs",
     "bake:probes": "node .tools/bake_probes.mjs",

--- a/test/player-controller.test.mjs
+++ b/test/player-controller.test.mjs
@@ -41,3 +41,154 @@ test('capsule stops at a wall without gaining launch velocity', () => {
   assert.ok(player.feetPosition.z > -35, `capsule crossed wall: z=${player.feetPosition.z}`);
   assert.ok(Math.abs(player.feetPosition.x) < 1000, `wall slide diverged: x=${player.feetPosition.x}`);
 });
+
+// The ladder prop is 27 wide, 140 tall and 5 deep, matching the baked Hijacked
+// volumes.  The roof it serves sits below the top of the rails, as it does on
+// the map, so topping out is a step over the lip rather than a clean landing.
+const LADDER_TOP = 140;
+const LADDER_Z = -50;
+const ROOF_Y = 120;
+
+function ladderWorld() {
+  const world = new THREE.Group();
+  const floor = new THREE.Mesh(new THREE.BoxGeometry(2000, 1, 2000));
+  floor.position.y = -0.5;
+  const ladder = new THREE.Mesh(new THREE.BoxGeometry(27, LADDER_TOP, 5));
+  ladder.position.set(0, LADDER_TOP / 2, LADDER_Z);
+  const roof = new THREE.Mesh(new THREE.BoxGeometry(400, 10, 150));
+  roof.position.set(0, ROOF_Y - 5, LADDER_Z - 2.5 - 75);
+  world.add(floor, ladder, roof);
+  world.updateWorldMatrix(true, true);
+  return world;
+}
+
+const LADDER_VOLUME = {
+  name: 'test_ladder',
+  center: [0, LADDER_TOP / 2, LADDER_Z],
+  right: [1, 0, 0],
+  normal: [0, 0, 1],
+  halfWidth: 13.5,
+  halfDepth: 2.5,
+  bottom: 0,
+  top: LADDER_TOP,
+};
+
+function ladderPlayer(options = {}) {
+  const camera = new THREE.PerspectiveCamera();
+  return new PlayerController(camera, ladderWorld(), {
+    spawn: new THREE.Vector3(0, 0.2, LADDER_Z + 25),
+    ladders: [LADDER_VOLUME],
+    ...options,
+  });
+}
+
+/** Run frames at 120 Hz, stopping early once `until` is satisfied. */
+function run(player, seconds, input, until = null) {
+  const frames = Math.round(seconds * 120);
+  for (let i = 0; i < frames; i += 1) {
+    player.update(1 / 120, input);
+    if (until && until(player)) return i / 120;
+  }
+  return seconds;
+}
+
+test('walking into a ladder climbs it and steps off at the top', () => {
+  const player = ladderPlayer();
+  // The camera looks down -Z by default, straight at the ladder face.
+  run(player, 0.3, { forward: true });
+  assert.ok(player.isOnLadder, 'player did not mount the ladder');
+  const mountedAt = player.feetPosition.y;
+
+  run(player, 0.5, { forward: true });
+  assert.ok(
+    player.feetPosition.y > mountedAt + 50,
+    `climb stalled: rose ${player.feetPosition.y - mountedAt} in half a second`,
+  );
+
+  run(player, 3, { forward: true }, (p) => !p.isOnLadder);
+  assert.equal(player.isOnLadder, false, 'player never left the ladder at the top');
+
+  // Release the stick so the player settles instead of sprinting off the roof.
+  run(player, 2, {});
+  assert.ok(
+    Math.abs(player.feetPosition.y - ROOF_Y) < 4,
+    `did not land on the roof: y=${player.feetPosition.y}`,
+  );
+  assert.ok(
+    player.feetPosition.z < LADDER_Z - 2.5,
+    `stepped off on the climbing side: z=${player.feetPosition.z}`,
+  );
+  assert.ok(player.isGrounded, 'player is not standing on the roof');
+});
+
+test('backing down a ladder returns to the floor and lets go', () => {
+  const player = ladderPlayer();
+  run(player, 0.5, { forward: true });
+  assert.ok(player.isOnLadder, 'player did not mount the ladder');
+  assert.ok(player.feetPosition.y > 40, `expected to be up the ladder: y=${player.feetPosition.y}`);
+
+  // Still facing the ladder, so pulling back off the face descends.
+  run(player, 3, { backward: true }, (p) => !p.isOnLadder);
+  assert.equal(player.isOnLadder, false, 'player never reached the bottom');
+
+  run(player, 0.5, {});
+  assert.ok(Math.abs(player.feetPosition.y) < 1, `did not settle on the floor: y=${player.feetPosition.y}`);
+});
+
+test('jumping off a ladder pushes clear of the face', () => {
+  const player = ladderPlayer();
+  run(player, 0.5, { forward: true });
+  assert.ok(player.isOnLadder, 'player did not mount the ladder');
+  const z = player.feetPosition.z;
+
+  player.update(1 / 120, { forward: true, jumpPressed: true });
+  assert.equal(player.isOnLadder, false, 'jump did not release the ladder');
+  assert.ok(player.velocity.y > 0, `jump gave no lift: vy=${player.velocity.y}`);
+
+  run(player, 0.2, {});
+  assert.ok(player.feetPosition.z > z + 10, `did not push away from the ladder: z=${player.feetPosition.z}`);
+});
+
+test('strafing past a ladder does not grab it', () => {
+  const player = ladderPlayer();
+  run(player, 1, { strafe: 1 });
+  assert.equal(player.isOnLadder, false, 'brushing past the ladder mounted it');
+  assert.ok(Math.abs(player.feetPosition.y) < 1, `left the floor: y=${player.feetPosition.y}`);
+});
+
+test('a climb blocked by geometry lets go instead of hanging', () => {
+  // One of the Hijacked ladders can be mounted from the face that is bolted to
+  // the map, where the climb has nowhere to go.
+  const world = ladderWorld();
+  const overhang = new THREE.Mesh(new THREE.BoxGeometry(200, 20, 40));
+  overhang.position.set(0, 110, LADDER_Z + 18.5);
+  world.add(overhang);
+  world.updateWorldMatrix(true, true);
+
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, world, {
+    spawn: new THREE.Vector3(0, 0.2, LADDER_Z + 25),
+    ladders: [LADDER_VOLUME],
+  });
+
+  run(player, 0.3, { forward: true });
+  assert.ok(player.isOnLadder, 'player did not mount the ladder');
+
+  const releasedAfter = run(player, 3, { forward: true }, (p) => !p.isOnLadder);
+  assert.equal(player.isOnLadder, false, 'player hung on a ladder it could not climb');
+  assert.ok(releasedAfter < 1, `took ${releasedAfter}s to give up on a blocked climb`);
+  assert.ok(
+    player.feetPosition.y < 40,
+    `expected to be stopped under the overhang: y=${player.feetPosition.y}`,
+  );
+});
+
+test('without ladder volumes the prop is just a wall', () => {
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, ladderWorld(), {
+    spawn: new THREE.Vector3(0, 0.2, LADDER_Z + 25),
+  });
+  run(player, 3, { forward: true });
+  assert.equal(player.isOnLadder, false);
+  assert.ok(Math.abs(player.feetPosition.y) < 1, `climbed without a volume: y=${player.feetPosition.y}`);
+});


### PR DESCRIPTION
## The problem

Ladders could not be climbed. This was not a bug — climbing was never implemented.

The T6 dump carries no ladder surface flags or trigger volumes, so the four Hijacked ladders arrived as nothing but solid collision triangles baked from the prop's LOD2 model (`hijacked_collision_source.json` shows `clt_ladder_construction_01` at 96 triangles). A ladder face has `normal.y ≈ 0`, so it never passed the `maxSlopeAngle: 45` floor test, and `_resolveCollisions` kept only the tangent — you slid along the ladder instead of going up it.

## The fix

**`.tools/bake_ladders.mjs`** (+ `npm run bake:ladders`) derives world-space climb volumes from ladder-named nodes in the collision glTF, node name being the only surviving thing that identifies a ladder. It picks the vertical axis by alignment with world up, then the wider of the remaining two as the rung axis, so it does not depend on how the prop was authored. Dependency-free, since it is a build script the browser never runs.

**`player-controller.js`** gains an attach/climb/dismount state:

- **Mount** requires being in the volume *and* pushing at the face, so brushing past does not grab it.
- **Climb** rate is the wish direction's component into the face — face it and press forward to go up, pull back to descend. Gravity is off while attached; a gap-closing grip holds the capsule to the face without fighting the collision resolver.
- **Dismount** on jump (pushes off), at the top (steps over the lip away from the climbing face), and on reaching the ground.

Both faces are climbable, because the export gives no hint which side is bolted to a wall.

## Verification

Driving the **real** collision BVH and baked volumes, all four ladders carry the player from the floor to standing on the surface above:

| ladder | start → end | ladder span |
|---|---|---|
| 0 | −44.0 → 91.8 | −43.5 → 96.4 |
| 1 | −172.0 → −44.0 | −176.5 → −36.6 |
| 2 | −106.0 → 20.0 | −114.5 → 25.4 |
| 3 | 20.0 → 156.1 | 20.0 → 159.9 |

That run caught a real bug: ladder 0's rear face mounts but has nowhere to climb, leaving the player hanging weightless. A stall guard releases the ladder after 0.4 s of no progress, which also covers overhangs and anything else the volumes cannot know about.

Unit tests go 7/7 in `test/player-controller.test.mjs` (6 new: climb-and-top-out, descend, jump-off, no false grab, blocked climb, and a no-volumes regression). Full suite 79 → 85 passing.

**Pre-existing failures, unchanged by this PR:** 5 unit tests fail on a clean checkout from missing `export/xanim` binaries and the T6 sound bank; `test:browser` times out because it needs the jsdelivr CDN.

## Note

`.tools/bake_ladders.mjs` needed `git add -f` — `.gitignore` starts with a blanket `*`, same as its sibling bake scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqKX3XxHUJc66YMmFa3j3r
