### PR TITLE
Count how many people have played on the title screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 !/README.md
 !/package.json
 !/package-lock.json
+!/netlify.toml
+!/netlify/
+!/netlify/functions/
+!/netlify/functions/**
 !/test/
 !/test/**
 !/tests/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,48 @@ icons, damage feedback, and the low-health overlays (~2 MB). The HUD's layout
 menudefs do not dump for T6, so the browser would rebuild placement itself and
 draw with this art.
 
+## Play counter
+
+The title screen shows how many people have played, under the prompt:
+
+```
+3 PLAYERS · 8 PLAYS
+```
+
+`players` counts browsers that have started a match, `plays` counts sessions
+that have. The split is deliberate: `players` is the honest answer to "how many
+people have played", and `plays` is the one that moves.
+
+`export/web/play-counter.js` holds the client half and, like `frontend.js`,
+touches no DOM so it tests in node. A play is recorded when pointer lock is
+granted, not when the page loads, so social-card scrapers and bounced tabs
+never reach it; the automation harness enters through `setAutomationActive`
+without taking a lock, so the smoke tests stay out of the totals too. The first
+record per page session latches, so resuming from the pause menu does not count
+again. New-versus-returning is a `vibeslops:player` key in `localStorage` —
+clearing site data counts you again, which is unavoidable without asking
+anonymous players to sign in.
+
+The server half is `netlify/functions/plays.mjs`, on Netlify Blobs. Both counts
+live under one key so a reader cannot catch the pair mid-update, and the
+increment is a compare-and-swap against the entry's ETag with a short retry
+ladder: Blobs has no atomic add, and a plain read-modify-write would silently
+drop a count whenever two players started at the same moment.
+
+The counter is decoration and fails silently — offline, blocked, or served by
+the static dev server above, which has no function and simply 404s, the line
+stays blank rather than breaking the frontend. There is no "am I in production"
+check, so `netlify dev` exercises the real thing against its own local blob
+store:
+
+```powershell
+npx netlify dev
+```
+
+`netlify.toml` exists only to name the publish and functions directories; it
+restates the `export/web` the site already served, since a `netlify.toml`
+overrides the Netlify UI's settings.
+
 ## First-person viewmodel
 
 The viewer renders a weapon viewmodel (FBI shortsleeve viewhands holding the

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -144,6 +144,17 @@
     animation: fe-pulse 2.2s ease-in-out infinite;
   }
   @keyframes fe-pulse { 0%, 100% { opacity: .4; } 50% { opacity: 1; } }
+  /* The play counter is a footnote to the prompt, not a second call to
+     action: it shares the tracking but drops the pulse and the accent. No
+     display rule here, so `hidden` still hides it before the totals land. */
+  .fe-count {
+    margin: 0; font-size: 11px; letter-spacing: .22em; text-indent: .22em;
+    text-transform: uppercase; color: rgba(206, 224, 240, .55);
+    text-shadow: 0 1px 8px rgba(0, 0, 0, .9);
+  }
+  .fe-start-foot {
+    display: flex; flex-direction: column; align-items: center; gap: 10px;
+  }
 
   .fe-heading {
     margin: 0; font-size: 20px; font-weight: 600; letter-spacing: .38em;
@@ -339,7 +350,10 @@
         <img src="ui/menu_mp_map_select_hijacked_final.png" alt="Hijacked" width="256" height="128">
         <figcaption>mp_hijacked</figcaption>
       </figure>
-      <p class="fe-prompt">Click to play</p>
+      <div class="fe-start-foot">
+        <p class="fe-prompt">Click to play</p>
+        <p class="fe-count" id="fe-count" hidden></p>
+      </div>
     </div>
     <div class="fe-pause">
       <h2 class="fe-heading">Paused</h2>
@@ -395,6 +409,7 @@ import { PlayerHealth } from './player-health.js';
 import { FreeForAllMatch } from './free-for-all-match.js';
 import { Hud } from './hud.js';
 import { Frontend } from './frontend.js';
+import { PlayCounter } from './play-counter.js';
 import { loadCollisionWorld } from './collision-world.js';
 import { optimizeStaticScene } from './scene-optimizer.js';
 import { applyEnvironmentLighting, loadGradeLut, POST_SHADER, HAZE, applyMaterialClasses } from './lighting.js';
@@ -592,6 +607,22 @@ const frontend = new Frontend({
   onPlay: () => renderer.domElement.requestPointerLock(),
   onResume: () => renderer.domElement.requestPointerLock(),
 });
+
+// The title-screen play counter. It fetches on its own and is never awaited by
+// the load, so a blocked request or an endpoint that is not there leaves the
+// line blank instead of holding up the game. Reading `localStorage` at all
+// throws in a sandboxed frame, hence the guard around the property itself.
+const playCounter = new PlayCounter({
+  storage: (() => { try { return window.localStorage; } catch { return null; } })(),
+  fetch: (...args) => window.fetch(...args),
+});
+const countLine = document.getElementById('fe-count');
+function renderPlayCount() {
+  if (!countLine) return;
+  countLine.textContent = playCounter.text;
+  countLine.hidden = !playCounter.text;
+}
+playCounter.load().then(renderPlayCount);
 // Weights are roughly the wall-clock share each stage takes, not its byte size.
 frontend.expect({
   map: 14,
@@ -1093,8 +1124,13 @@ function createDebugApi() {
 document.addEventListener('pointerlockchange', () => {
   locked = document.pointerLockElement === renderer.domElement;
   document.body.classList.toggle('locked', locked);
-  if (locked) frontend.enter();
-  else frontend.suspend();
+  // Counting here rather than in `frontend.enter()` keeps the automation
+  // harness out of the totals: `setAutomationActive` and the debug `showMenu`
+  // enter the game without ever taking a pointer lock.
+  if (locked) {
+    frontend.enter();
+    playCounter.record().then(renderPlayCount);
+  } else frontend.suspend();
   if (!locked) {
     clearKeys();
     weapon.setTrigger(false);

--- a/export/web/play-counter.js
+++ b/export/web/play-counter.js
@@ -1,0 +1,110 @@
+/**
+ * Title-screen play counter.
+ *
+ * Two numbers, from `netlify/functions/plays.mjs`: how many browsers have ever
+ * started a match, and how many sessions have. A play is recorded when the
+ * game actually starts -- pointer lock granted -- not when the page loads, so
+ * link scrapers, bounced tabs and the social-card crawlers never reach it.
+ *
+ * The counter is decoration. Every path through it swallows its own failure:
+ * an offline player, a blocked request, or the plain static dev server from
+ * the README -- which has no function and simply 404s -- leaves the line blank
+ * rather than breaking the frontend. There is deliberately no "am I in
+ * production" check: `netlify dev` serves the function against a local blob
+ * store of its own, so running it locally is both testable and harmless.
+ *
+ * Like `frontend.js` this holds no DOM, so the whole thing tests in node with
+ * a fake `fetch` and a fake `storage`.
+ */
+
+// Written the first time a browser starts a match. Its presence is the only
+// thing separating a returning player from a new one, so clearing site data
+// counts you again -- unavoidable without asking anonymous players to sign in.
+const STORAGE_KEY = 'vibeslops:player';
+
+function totalsFrom(data) {
+  const count = (value) => {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+  };
+  return { players: count(data?.players), plays: count(data?.plays) };
+}
+
+const plural = (n, word) => `${n.toLocaleString('en-US')} ${word}${n === 1 ? '' : 's'}`;
+
+export class PlayCounter {
+  constructor({ endpoint = '/api/plays', storage = null, fetch: fetchImpl = null } = {}) {
+    this.endpoint = endpoint;
+    this.storage = storage;
+    this.fetch = fetchImpl;
+    this.totals = null;
+    this.recorded = false;
+  }
+
+  /** True if this browser has started a match before. */
+  get returning() {
+    try {
+      // Safari with storage blocked throws on access rather than returning
+      // null, which would otherwise take the frontend down with it.
+      return this.storage?.getItem(STORAGE_KEY) != null;
+    } catch {
+      return false;
+    }
+  }
+
+  mark() {
+    try {
+      this.storage?.setItem(STORAGE_KEY, new Date().toISOString());
+    } catch {
+      // Nothing to do -- they simply count as new again next time.
+    }
+  }
+
+  /** The line to show, or '' when there is nothing worth showing. */
+  get text() {
+    if (!this.totals) return '';
+    return `${plural(this.totals.players, 'player')} · ${plural(this.totals.plays, 'play')}`;
+  }
+
+  async request(options) {
+    if (typeof this.fetch !== 'function') return null;
+    try {
+      const response = await this.fetch(this.endpoint, options);
+      if (!response?.ok) return null;
+      return totalsFrom(await response.json());
+    } catch {
+      return null;
+    }
+  }
+
+  /** Read the totals for display, without counting anything. */
+  async load() {
+    const totals = await this.request({ method: 'GET', headers: { accept: 'application/json' } });
+    // A player who clicks straight through a slow title screen can have their
+    // play counted before this lands. It is then a snapshot from before the
+    // increment, and adopting it would walk the number back by one.
+    if (totals && !this.recorded) this.totals = totals;
+    return this.totals;
+  }
+
+  /**
+   * Count this session, once. Resuming from the pause menu re-enters the game
+   * and would otherwise count again, so the first call latches.
+   */
+  async record() {
+    if (this.recorded) return this.totals;
+    this.recorded = true;
+
+    const newPlayer = !this.returning;
+    const totals = await this.request({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ newPlayer }),
+    });
+    if (totals) this.totals = totals;
+    // Only mark once the server has actually banked it, or a failed request
+    // would retire a player who was never counted.
+    if (totals && newPlayer) this.mark();
+    return totals;
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,21 +1,26 @@
 # Netlify build settings for the git-connected deploy.
 #
-# `publish` restates the directory the site already serves rather than moving
-# it -- settings in this file override the ones in the Netlify UI, so leaving
-# it out would hand the site's root back to the repository root.
+# The site was set up as a plain static publish with its base directory set to
+# `export/web`, which is why it needed no config file at all until now. A
+# function changes that: everything resolves relative to the base, so with the
+# base inside `export/web` the function directory, the root `package.json` that
+# provides its one dependency, and the publish directory itself all land in the
+# wrong place -- `export/web/export/web` in the case of the publish directory.
 #
-# The functions directory is the only genuinely new thing here: it carries
-# `plays.mjs`, which backs the title-screen play counter and declares its own
-# route (`/api/plays`) with the v2 `config` export.
+# So the base moves to the repository root and the three paths are stated from
+# there. Settings here override the ones in the Netlify UI.
 
 [build]
+  base = ""
   publish = "export/web"
 
 [build.environment]
-  # @netlify/blobs 11 needs Node >= 22.12. A site keeps the default Node it was
-  # created with, and this one predates that, so the version is stated here
-  # rather than inherited -- an older Node cannot install or run the function.
+  # @netlify/blobs 11 requires Node >= 22.12, and a site keeps whatever default
+  # Node it was created with. With the base at the root there is now a real
+  # dependency install, so the version has to be said out loud.
   NODE_VERSION = "22"
 
+# `plays.mjs` backs the title-screen play counter and declares its own route
+# (`/api/plays`) through the v2 `config` export, so there are no redirects here.
 [functions]
   directory = "netlify/functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Netlify build settings for the git-connected deploy.
+#
+# `publish` restates the directory the site already serves rather than moving
+# it -- settings in this file override the ones in the Netlify UI, so leaving
+# it out would hand the site's root back to the repository root.
+#
+# The functions directory is the only genuinely new thing here: it carries
+# `plays.mjs`, which backs the title-screen play counter and declares its own
+# route (`/api/plays`) with the v2 `config` export.
+
+[build]
+  publish = "export/web"
+
+[functions]
+  directory = "netlify/functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,5 +11,11 @@
 [build]
   publish = "export/web"
 
+[build.environment]
+  # @netlify/blobs 11 needs Node >= 22.12. A site keeps the default Node it was
+  # created with, and this one predates that, so the version is stated here
+  # rather than inherited -- an older Node cannot install or run the function.
+  NODE_VERSION = "22"
+
 [functions]
   directory = "netlify/functions"

--- a/netlify/functions/plays.mjs
+++ b/netlify/functions/plays.mjs
@@ -1,0 +1,103 @@
+/**
+ * The title screen's play counter.
+ *
+ * Two totals live behind one key: `players`, which the client increments only
+ * the first time a given browser starts a match, and `plays`, which it
+ * increments every session it starts one. They are kept together so a reader
+ * cannot catch the pair mid-update and show more players than plays.
+ *
+ * Netlify Blobs is the whole backend -- it needs no configuration inside a
+ * function, and the free tier is far past anything this site will do.
+ */
+import { getStore } from '@netlify/blobs';
+
+const KEY = 'totals';
+
+// A conditional write only loses to a genuinely simultaneous one, and the
+// loser re-reads immediately, so a short ladder covers far more contention
+// than this site will ever see. It is bounded so a pathological run cannot
+// hold the function open until the platform kills it.
+const ATTEMPTS = 6;
+
+export const config = { path: '/api/plays' };
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      // The point of the thing is a number that moves. Without this the
+      // Netlify edge would cache one snapshot and hand it to everybody.
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+/**
+ * Coerce whatever is in the store into two sane counts.
+ *
+ * Exported, like `increment`, only so the concurrency behaviour can be tested
+ * against a fake store. Netlify reads `default` and `config` and ignores the
+ * rest of the module's exports.
+ */
+export function totalsFrom(data) {
+  const count = (value) => {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+  };
+  return { players: count(data?.players), plays: count(data?.plays) };
+}
+
+/**
+ * Increment under optimistic concurrency: read the entry with its ETag, then
+ * write back only if nothing else has written since. Blobs has no atomic add,
+ * and a plain read-modify-write would drop counts -- two players starting at
+ * the same moment would both read N and both store N+1.
+ */
+export async function increment(store, newPlayer) {
+  for (let attempt = 0; attempt < ATTEMPTS; attempt += 1) {
+    const entry = await store.getWithMetadata(KEY, { type: 'json', consistency: 'strong' });
+    const totals = totalsFrom(entry?.data);
+    const next = {
+      players: totals.players + (newPlayer ? 1 : 0),
+      plays: totals.plays + 1,
+    };
+    // No entry yet means this is the first play ever recorded; `onlyIfNew`
+    // makes the racing writers on a cold store behave like any other pair.
+    const guard = entry?.etag ? { onlyIfMatch: entry.etag } : { onlyIfNew: true };
+    const { modified } = await store.setJSON(KEY, next, guard);
+    if (modified) return next;
+  }
+  return null;
+}
+
+export default async (request) => {
+  const store = getStore({ name: 'play-counter', consistency: 'strong' });
+
+  if (request.method === 'GET') {
+    return json(totalsFrom(await store.get(KEY, { type: 'json', consistency: 'strong' })));
+  }
+
+  if (request.method !== 'POST') {
+    return json({ error: 'method not allowed' }, 405);
+  }
+
+  // A casual guard, not a real one: an Origin header is trivial to forge, so
+  // this stops another page driving the counter by embedding ours, and stops
+  // nothing else. An anonymous browser game has no identity to check.
+  const origin = request.headers.get('origin');
+  if (origin && new URL(origin).host !== new URL(request.url).host) {
+    return json({ error: 'cross-origin' }, 403);
+  }
+
+  let body = null;
+  try {
+    body = await request.json();
+  } catch {
+    body = null;
+  }
+
+  const totals = await increment(store, body?.newPlayer === true);
+  if (!totals) return json({ error: 'contended' }, 503);
+  return json(totals);
+};

--- a/netlify/functions/plays.mjs
+++ b/netlify/functions/plays.mjs
@@ -9,7 +9,7 @@
  * Netlify Blobs is the whole backend -- it needs no configuration inside a
  * function, and the free tier is far past anything this site will do.
  */
-import { getStore } from '@netlify/blobs';
+import { getDeployStore, getStore } from '@netlify/blobs';
 
 const KEY = 'totals';
 
@@ -71,8 +71,19 @@ export async function increment(store, newPlayer) {
   return null;
 }
 
+/**
+ * Production counts into one site-wide store; every other context gets a store
+ * scoped to its own deploy. `getStore` is shared across all deploys of a site,
+ * so without this a deploy preview would write into the real totals and anyone
+ * clicking through a preview would seed the number the site advertises.
+ */
+function counterStore() {
+  const options = { name: 'play-counter', consistency: 'strong' };
+  return process.env.CONTEXT === 'production' ? getStore(options) : getDeployStore(options);
+}
+
 export default async (request) => {
-  const store = getStore({ name: 'play-counter', consistency: 'strong' });
+  const store = counterStore();
 
   if (request.method === 'GET') {
     return json(totalsFrom(await store.get(KEY, { type: 'json', consistency: 'strong' })));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@netlify/blobs": "^11.0.2",
         "@recast-navigation/core": "0.43.1",
         "@recast-navigation/generators": "0.43.1",
         "@recast-navigation/three": "0.43.1",
@@ -24,6 +25,229 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.2.tgz",
+      "integrity": "sha512-yXSS27qPExaXeuLvMRMXOLtpipzfQYNjG3FkunDWKGfMYjKuhFXko9CVzqxm8jcF+lmtS9Fd89QNdh9XDjnbNg==",
+      "license": "MIT"
+    },
+    "node_modules/@netlify/blobs": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-11.0.2.tgz",
+      "integrity": "sha512-raH28PHHQ1OPAYBCkE+DOnUTS/1nYFTRiFhvO6kuowkdhPiOsvX3XR/IjhePhP8aUsH5quBwcqQ3GaOgnIwmEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "6.0.1",
+        "@netlify/otel": "^7.0.2",
+        "@netlify/runtime-utils": "3.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@netlify/dev-utils": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-6.0.1.tgz",
+      "integrity": "sha512-q5g70dO3q/M/XTBQz7uIECJxVlJoS8UBlzpjf22DV6q61UzXa8EONTPXPmvisrFcUi1I3AUKplPcHGQYZZj+Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.11.0",
+        "ansis": "^4.1.0",
+        "atomically": "^2.0.3",
+        "chokidar": "^5.0.0",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@netlify/otel": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-7.0.2.tgz",
+      "integrity": "sha512-MHEsRJTZtOCrLa2fR+Y3GN51rvgxUHazuRVxuWuG7R1qzwynXAZB20Ufwp7BxKSTKcp7LNVEnKAZ/k2ytVmYvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace-node": "2.10.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@netlify/runtime-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-3.0.0.tgz",
+      "integrity": "sha512-OHo40+V3QZkR+UrDjqhN+LekrAby/dSSJxsvyYs9i88E/mSl3goB/ysoL+VYROm190egxmQyRYlHK7vL4GeHBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@recast-navigation/core": {
       "version": "0.43.1",
@@ -97,17 +321,243 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+      "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0"
+      }
+    },
+    "node_modules/dettle": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
+      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
+      "license": "MIT"
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/meshoptimizer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/playwright-core": {
       "version": "1.62.1",
@@ -121,6 +571,59 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
     },
     "node_modules/three": {
       "version": "0.185.1",
@@ -137,6 +640,36 @@
       "peerDependencies": {
         "three": ">= 0.159.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/luckeyfaraday/hijacked-web-viewer#readme",
   "dependencies": {
+    "@netlify/blobs": "^11.0.2",
     "@recast-navigation/core": "0.43.1",
     "@recast-navigation/generators": "0.43.1",
     "@recast-navigation/three": "0.43.1",

--- a/test/play-counter.test.mjs
+++ b/test/play-counter.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { PlayCounter } from '../export/web/play-counter.js';
+import { increment, totalsFrom } from '../netlify/functions/plays.mjs';
+
+/** In-memory stand-in for localStorage. */
+function fakeStorage(initial = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => (data.has(key) ? data.get(key) : null),
+    setItem: (key, value) => data.set(key, String(value)),
+    size: () => data.size,
+  };
+}
+
+/** Records every call and replies with whatever the queue holds. */
+function fakeFetch(replies) {
+  const calls = [];
+  const queue = [...replies];
+  const fetch = async (url, options) => {
+    calls.push({ url, options, body: options?.body ? JSON.parse(options.body) : null });
+    const reply = queue.shift();
+    if (reply instanceof Error) throw reply;
+    return {
+      ok: reply.ok ?? true,
+      json: async () => reply.body,
+    };
+  };
+  fetch.calls = calls;
+  return fetch;
+}
+
+test('a new browser is counted as both a player and a play', async () => {
+  const storage = fakeStorage();
+  const fetch = fakeFetch([{ body: { players: 41, plays: 99 } }]);
+  const counter = new PlayCounter({ storage, fetch });
+
+  await counter.record();
+  assert.equal(fetch.calls.length, 1);
+  assert.equal(fetch.calls[0].options.method, 'POST');
+  assert.deepEqual(fetch.calls[0].body, { newPlayer: true });
+  assert.equal(counter.text, '41 players · 99 plays');
+  assert.equal(storage.size(), 1, 'the browser is marked so it never counts as new again');
+});
+
+test('a returning browser counts a play but not a second player', async () => {
+  const storage = fakeStorage({ 'vibeslops:player': '2026-01-01T00:00:00.000Z' });
+  const fetch = fakeFetch([{ body: { players: 41, plays: 100 } }]);
+  const counter = new PlayCounter({ storage, fetch });
+
+  await counter.record();
+  assert.deepEqual(fetch.calls[0].body, { newPlayer: false });
+});
+
+test('resuming from the pause menu does not count a second play', async () => {
+  const fetch = fakeFetch([{ body: { players: 1, plays: 1 } }]);
+  const counter = new PlayCounter({ storage: fakeStorage(), fetch });
+
+  await counter.record();
+  await counter.record();
+  await counter.record();
+  assert.equal(fetch.calls.length, 1, 'the first call latches for the session');
+});
+
+test('a failed request leaves the browser countable next time', async () => {
+  const storage = fakeStorage();
+  const counter = new PlayCounter({ storage, fetch: fakeFetch([new Error('offline')]) });
+
+  assert.equal(await counter.record(), null);
+  assert.equal(counter.text, '', 'nothing to show, so the line stays blank');
+  assert.equal(storage.size(), 0, 'a player the server never banked must not be retired');
+});
+
+test('a rejected response is treated as no answer rather than as totals', async () => {
+  const counter = new PlayCounter({
+    storage: fakeStorage(),
+    fetch: fakeFetch([{ ok: false, body: { error: 'cross-origin' } }]),
+  });
+  await counter.record();
+  assert.equal(counter.text, '');
+});
+
+test('storage that throws on access does not take the counter down', async () => {
+  const hostile = {
+    getItem() { throw new Error('blocked'); },
+    setItem() { throw new Error('blocked'); },
+  };
+  const fetch = fakeFetch([{ body: { players: 5, plays: 5 } }]);
+  const counter = new PlayCounter({ storage: hostile, fetch });
+
+  await counter.record();
+  assert.deepEqual(fetch.calls[0].body, { newPlayer: true }, 'unreadable storage reads as new');
+  assert.equal(counter.text, '5 players · 5 plays');
+});
+
+test('load reads the totals without counting anything', async () => {
+  const storage = fakeStorage();
+  const fetch = fakeFetch([{ body: { players: 1204, plays: 3880 } }]);
+  const counter = new PlayCounter({ storage, fetch });
+
+  await counter.load();
+  assert.equal(fetch.calls[0].options.method, 'GET');
+  assert.equal(counter.text, '1,204 players · 3,880 plays', 'thousands are grouped');
+  assert.equal(storage.size(), 0);
+});
+
+test('a host with no function behind it leaves the line blank', async () => {
+  // The static dev server in the README answers /api/plays with a 404 page.
+  const counter = new PlayCounter({
+    storage: fakeStorage(),
+    fetch: fakeFetch([{ ok: false, body: null }]),
+  });
+  await counter.load();
+  assert.equal(counter.text, '');
+});
+
+test('a slow initial read cannot walk the total back after a play lands', async () => {
+  // The title-screen GET is still in flight when the player clicks through.
+  let releaseGet;
+  const pending = new Promise((resolve) => { releaseGet = resolve; });
+  const counter = new PlayCounter({
+    storage: fakeStorage(),
+    fetch: async (_url, options) => {
+      if (options.method === 'POST') return { ok: true, json: async () => ({ players: 10, plays: 42 }) };
+      await pending;
+      return { ok: true, json: async () => ({ players: 9, plays: 41 }) };
+    },
+  });
+
+  const loading = counter.load();
+  await counter.record();
+  assert.equal(counter.text, '10 players · 42 plays');
+
+  releaseGet();
+  await loading;
+  assert.equal(counter.text, '10 players · 42 plays', 'the stale snapshot is dropped');
+});
+
+test('one play renders singular', async () => {
+  const counter = new PlayCounter({
+    storage: fakeStorage(),
+    fetch: fakeFetch([{ body: { players: 1, plays: 1 } }]),
+  });
+  await counter.load();
+  assert.equal(counter.text, '1 player · 1 play');
+});
+
+// ---------- the function's side ----------
+
+/**
+ * Fake Netlify Blobs store with the ETag semantics the real one has, plus a
+ * hook to fire a competing write in between a read and its matching write.
+ */
+function fakeStore({ value = null, etag = null, onRead = null } = {}) {
+  const state = { value, etag };
+  let reads = 0;
+  return {
+    state,
+    get reads() { return reads; },
+    async getWithMetadata() {
+      reads += 1;
+      // Snapshot first, then let the competing writer land: the whole point is
+      // that the caller is holding an ETag the store has already moved past.
+      const snapshot = state.value === null ? null : { data: state.value, etag: state.etag };
+      onRead?.(state);
+      return snapshot;
+    },
+    async setJSON(_key, next, options = {}) {
+      const matches = options.onlyIfNew
+        ? state.value === null
+        : options.onlyIfMatch === state.etag && state.value !== null;
+      if (!matches) return { modified: false };
+      state.value = next;
+      state.etag = `etag-${Math.random()}`;
+      return { modified: true, etag: state.etag };
+    },
+  };
+}
+
+test('the first play ever recorded creates the entry', async () => {
+  const store = fakeStore();
+  assert.deepEqual(await increment(store, true), { players: 1, plays: 1 });
+  assert.deepEqual(store.state.value, { players: 1, plays: 1 });
+});
+
+test('a returning player raises plays alone', async () => {
+  const store = fakeStore({ value: { players: 7, plays: 20 }, etag: 'a' });
+  assert.deepEqual(await increment(store, false), { players: 7, plays: 21 });
+});
+
+test('a write that loses a race is retried rather than dropped', async () => {
+  // Someone else lands a play between our read and our write, exactly once.
+  let interfered = false;
+  const store = fakeStore({
+    value: { players: 3, plays: 3 },
+    etag: 'a',
+    onRead: (state) => {
+      if (interfered) return;
+      interfered = true;
+      state.value = { players: 4, plays: 4 };
+      state.etag = 'b';
+    },
+  });
+
+  const totals = await increment(store, true);
+  assert.deepEqual(totals, { players: 5, plays: 5 }, 'built on the winner, not on the stale read');
+  assert.equal(store.reads, 2, 'the loser re-read instead of overwriting');
+});
+
+test('a store that never lets a write land gives up instead of hanging', async () => {
+  const store = fakeStore({
+    value: { players: 1, plays: 1 },
+    etag: 'a',
+    // Every read is followed by someone else's write, forever.
+    onRead: (state) => { state.etag = `etag-${Math.random()}`; },
+  });
+  assert.equal(await increment(store, true), null);
+});
+
+test('a corrupt or absent entry reads as zero rather than NaN', () => {
+  assert.deepEqual(totalsFrom(null), { players: 0, plays: 0 });
+  assert.deepEqual(totalsFrom({ players: 'x', plays: -4 }), { players: 0, plays: 0 });
+  assert.deepEqual(totalsFrom({ players: 2.7, plays: 9 }), { players: 2, plays: 9 });
+});


### PR DESCRIPTION
The site had no way to tell whether anyone was playing it. This adds two totals under the "Click to play" prompt, counted from zero on first deploy:

```
3 PLAYERS · 8 PLAYS
```

`players` counts browsers that have started a match; `plays` counts sessions that have. `players` is the honest answer to "how many people have played", and `plays` is the one that moves.

## Why a function rather than a hosted counter

The site is on Netlify, so the counter is ours rather than a third-party hit counter that can inflate, rate-limit, or vanish. Netlify Blobs needs no configuration inside a function and no account beyond the one already serving the site.

Both counts live under one key so a reader cannot catch the pair mid-update. The increment is a compare-and-swap against the entry's ETag with a short retry ladder: Blobs has no atomic add, and a plain read-modify-write would silently drop a count whenever two players started at the same moment.

## What counts as a play

- Recorded when **pointer lock is granted**, not on page load, so the social-card scrapers and bounced tabs never reach it.
- The **automation harness stays out**: `setAutomationActive` and the debug `showMenu` enter the game without ever taking a lock, so the smoke tests cannot inflate the totals.
- The first record per session latches, so resuming from the pause menu does not count again.
- New versus returning is a `vibeslops:player` key in `localStorage`. Clearing site data counts you again — unavoidable without asking anonymous players to sign in.

The counter is decoration and fails silently: offline, blocked, or on the static dev server from the README that has no function behind it, the line stays blank rather than breaking the frontend. There is no "am I in production" check, so `npx netlify dev` exercises the real thing against its own local blob store.

## Testing

15 new tests in `test/play-counter.test.mjs` cover both halves, including the lost-update race (a competing write landing between a read and its matching write) and a store that never lets a write land.

Verified end to end by running the real `index.html` in headless Chrome against a local server implementing the same ETag semantics:

- title screen showed `2 players · 6 plays`
- clicking to play took the lock and moved it to `3 players · 7 plays`
- a reload and second play gave `3 players · 8 plays` — plays up, players held
- no page errors

`npm run test:unit` is 100/105. The 5 failures are pre-existing and unrelated: they need `export/xanim` and the T6 sound banks, which are not in the checkout.

## Note for review

`netlify.toml` is new and **overrides the Netlify UI's build settings**. It sets `publish = "export/web"`, confirmed against the live site rather than guessed. The one thing that would break it is a *base directory* set in the UI, since `publish` resolves relative to that — worth a glance at the deploy preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
