### PR TITLE
Cut the published site from 194 MB to 64 MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !/.tools/bake_map.mjs
 !/.tools/bake_env.mjs
 !/.tools/bake_probes.mjs
+!/.tools/prune-deploy.sh
 !/.tools/perf_probe.mjs
 !/.tools/xanim_to_json.mjs
 !/.tools/extract_t6_sab_audio.mjs

--- a/.tools/bake_map.mjs
+++ b/.tools/bake_map.mjs
@@ -36,12 +36,13 @@ try {
     '--simplify', 'false',
     '--texture-compress', 'false',
   ]);
+  // ETC1S, not UASTC. Every texture in this map is a baseColor map -- there are
+  // no normal or metal-rough maps, which are the maps ETC1S actually degrades.
+  // UASTC was costing ~34 MB of the 45 MB export for quality nothing here uses.
   await run([
-    'uastc', intermediate, output,
-    '--level', '2',
-    '--rdo',
-    '--rdo-lambda', '0.75',
-    '--zstd', '10',
+    'etc1s', intermediate, output,
+    '--quality', '200',
+    '--compression', '5',
     '--jobs', '8',
   ]);
 } finally {

--- a/.tools/prune-deploy.sh
+++ b/.tools/prune-deploy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Strips build inputs from the publish directory before Netlify uploads it.
+#
+# `export/web` doubles as the bake workspace: `compose_scene.py` writes
+# hijacked.gltf/.bin there, `export_collision.py` writes the collision source
+# beside it, and `textures/` holds the 359 source PNGs that `bake_map.mjs`
+# encodes into hijacked_optimized.glb. None of that is fetched by the browser --
+# the runtime reads the baked .glb, the baked BVH, and a handful of loose
+# textures -- but all of it was being served, and crawlers were pulling it.
+#
+# Netlify builds in a throwaway container, so deleting here never touches git.
+set -euo pipefail
+
+WEB="export/web"
+cd "$(dirname "$0")/.."
+
+# Loose textures the runtime still fetches directly (lighting.js, index.html).
+# Everything else under textures/ is a bake input.
+KEEP_TEXTURES=(env probe mp_hijacked_lut.png)
+
+require() {
+  [ -e "$1" ] || { echo "prune-deploy: expected runtime asset missing: $1" >&2; exit 1; }
+}
+
+# Fail loudly rather than shipping a broken map if an asset was renamed.
+require "$WEB/hijacked_optimized.glb"
+require "$WEB/hijacked_collision_bvh.bin"
+require "$WEB/hijacked_collision_bvh.json"
+require "$WEB/hijacked.navmesh.bin"
+for keep in "${KEEP_TEXTURES[@]}"; do require "$WEB/textures/$keep"; done
+
+before=$(du -sm "$WEB" | cut -f1)
+
+# Bake inputs and intermediates.
+rm -f "$WEB"/hijacked.gltf \
+      "$WEB"/hijacked.bin \
+      "$WEB"/hijacked_geometry.glb \
+      "$WEB"/hijacked_collision.gltf \
+      "$WEB"/hijacked_collision.bin \
+      "$WEB"/hijacked_collision_source.json
+
+# Source PNGs, now embedded in the .glb as KTX2.
+find "$WEB/textures" -maxdepth 1 -type f -name '*.png' \
+  ! -name 'mp_hijacked_lut.png' -delete
+
+after=$(du -sm "$WEB" | cut -f1)
+echo "prune-deploy: publish dir ${before} MB -> ${after} MB"

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,11 @@
 [build]
   base = ""
   publish = "export/web"
+  # `export/web` is also the bake workspace, so the publish dir carried ~108 MB
+  # of build inputs -- the source .gltf/.bin the map is baked from and the 359
+  # source PNGs already embedded in the .glb as KTX2. Nothing fetches them;
+  # crawlers pulled them anyway. This strips them from the upload only.
+  command = ".tools/prune-deploy.sh"
 
 [build.environment]
   # @netlify/blobs 11 requires Node >= 22.12, and a site keeps whatever default


### PR DESCRIPTION
The Netlify usage graph spiked to **58.1 GB in a single day** against 19.4 GB for all of August, on a Free plan with a 100 GB cap. Two causes, both in `export/web`.

## 1. The publish directory was shipping its own build inputs

`export/web` doubles as the bake workspace, so Netlify was serving:

| file | size | what it is |
|---|---|---|
| `hijacked.gltf` + `hijacked.bin` | 45.6 MB | the source the map is baked *from* |
| `hijacked_collision.gltf` + `.bin` + `_source.json` | 3.9 MB | the source the BVH is baked *from* |
| `textures/*.png` (359 files) | 59.0 MB | already embedded in the `.glb` as KTX2 |

**108 MB that nothing in the browser fetches.** I traced every asset path in the JS and HTML — including the template-string ones in `enemy-system.js`, `lighting.js`, `light-probes.js` and `viewmodel.js` — and the only things the runtime pulls out of `textures/` are `env/`, `probe/` and `mp_hijacked_lut.png`. Crawlers were pulling the rest.

`.tools/prune-deploy.sh` strips them from the upload. Netlify builds in a throwaway container, so the repo keeps every one of them and the bake pipeline is untouched. The script `require`s each runtime asset up front and hard-fails, so a future rename breaks the build instead of silently shipping a map with no textures.

## 2. The map was encoded UASTC

UASTC cost **34 MB of the 45 MB export**. Every texture in this map is a `baseColorTexture` — 350 of them, and not one normal or metal-rough map, which are the maps ETC1S actually degrades. The quality UASTC was buying went unused.

`bake_map.mjs` is switched to ETC1S so a rebuild doesn't quietly restore the old size. `index.html` already registers both `KTX2Loader` and `MeshoptDecoder`, so this needed no runtime changes.

## Results

| | before | after |
|---|---|---|
| `hijacked_optimized.glb` | 45.5 MB | **22.6 MB** |
| publish dir | 193.8 MB | **64 MB** |
| per visitor | ~52 MB | **~29 MB** |

At the current ~600 visitors/day that's **58 GB/day → ~17 GB/day**, and the crawler-reachable surface drops from 194 MB to 64 MB.

## Verification

Rendered both builds headlessly through `GLTFLoader` + `KTX2Loader` + `MeshoptDecoder` from an identical camera framed on `world_shell`:

- **PSNR 44.9 dB** mid-range, **44.2 dB** macro (40 dB is the visually-lossless threshold)
- mean absolute difference **0.80/255**; 0.1% of pixels differ by more than 8/255
- both builds load **350 textures / 864 geometries** with an identical bounding box

Then served the fully pruned `export/web` and loaded `index.html`: title screen and map thumbnail render, no missing assets. The only 404 is `/api/plays`, which is the Netlify function a plain static server doesn't have.

Worth watching on the deploy preview: this is the first build to run a `command`, so confirm `prune-deploy.sh` reports `194 MB -> 64 MB` in the build log and the map still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFX6KomqErnaBsWYky6LKx