### PR TITLE
Move the browser game to Cloudflare Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@
 !/netlify/
 !/netlify/functions/
 !/netlify/functions/**
+!/wrangler.jsonc
+!/functions/
+!/functions/**
+!/migrations/
+!/migrations/**
 !/test/
 !/test/**
 !/tests/
@@ -31,6 +36,7 @@
 !/.tools/bake_env.mjs
 !/.tools/bake_probes.mjs
 !/.tools/prune-deploy.sh
+!/.tools/stage_cloudflare.mjs
 !/.tools/perf_probe.mjs
 !/.tools/xanim_to_json.mjs
 !/.tools/extract_t6_sab_audio.mjs

--- a/.tools/stage_cloudflare.mjs
+++ b/.tools/stage_cloudflare.mjs
@@ -1,0 +1,48 @@
+import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = path.join(root, 'export', 'web');
+const destination = path.join(root, '.work', 'cloudflare-pages');
+
+const omittedRootFiles = new Set([
+  'hijacked.gltf',
+  'hijacked.bin',
+  'hijacked_geometry.glb',
+  'hijacked_collision.gltf',
+  'hijacked_collision.bin',
+  'hijacked_collision_source.json',
+]);
+const keptLooseTextures = new Set(['mp_hijacked_lut.png']);
+
+function include(candidate) {
+  const relative = path.relative(source, candidate);
+  if (!relative) return true;
+  const segments = relative.split(path.sep);
+  if (segments.length === 1 && omittedRootFiles.has(segments[0])) return false;
+  if (
+    segments.length === 2
+    && segments[0] === 'textures'
+    && segments[1].endsWith('.png')
+    && !keptLooseTextures.has(segments[1])
+  ) return false;
+  return true;
+}
+
+for (const required of [
+  'hijacked_optimized.glb',
+  'hijacked_collision_bvh.bin',
+  'hijacked_collision_bvh.json',
+  'hijacked.navmesh.bin',
+  path.join('textures', 'env'),
+  path.join('textures', 'probe'),
+  path.join('textures', 'mp_hijacked_lut.png'),
+]) {
+  await stat(path.join(source, required));
+}
+
+await mkdir(path.dirname(destination), { recursive: true });
+await rm(destination, { recursive: true, force: true });
+await cp(source, destination, { recursive: true, filter: include });
+console.log(`Staged Cloudflare Pages assets in ${path.relative(root, destination)}`);

--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ The title screen shows how many people have played, under the prompt:
 3 PLAYERS · 8 PLAYS
 ```
 
+Production is being migrated from Netlify to Cloudflare Pages. The Cloudflare
+backend is `functions/api/plays.js`, with separate D1 databases for production
+and branch previews so automated checks and preview visits cannot change the
+public totals. `wrangler.jsonc` is the source of truth for those bindings.
+
+Cloudflare cannot upload the bake inputs that live beside the runtime export:
+some are unused and one exceeds Pages' per-file limit. The staging command
+copies only the same runtime package Netlify publishes, without deleting files
+from the working tree:
+
+```powershell
+npm run cloudflare:stage
+npm run cloudflare:dev
+```
+
+Apply `migrations/0001_play_counter.sql` to both D1 databases once, then deploy
+the staged package with `npm run cloudflare:deploy`. Branch deployments select
+the preview database through `CF_PAGES_BRANCH`; only `main` uses the production
+counter.
+
 `players` counts browsers that have started a match, `plays` counts sessions
 that have. The split is deliberate: `players` is the honest answer to "how many
 people have played", and `plays` is the one that moves.

--- a/functions/api/plays.js
+++ b/functions/api/plays.js
@@ -1,0 +1,67 @@
+const EMPTY_TOTALS = Object.freeze({ players: 0, plays: 0 });
+
+function json(body, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: { 'cache-control': 'no-store' },
+  });
+}
+
+export function totalsFrom(data) {
+  const count = (value) => {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+  };
+  return { players: count(data?.players), plays: count(data?.plays) };
+}
+
+export function counterDatabase(env) {
+  return env.CF_PAGES_BRANCH === 'main'
+    ? env.PLAY_COUNTER
+    : env.PLAY_COUNTER_PREVIEW;
+}
+
+export async function increment(database, newPlayer) {
+  const row = await database.prepare(`
+    UPDATE play_totals
+       SET players = players + ?1,
+           plays = plays + 1
+     WHERE id = 1
+     RETURNING players, plays
+  `).bind(newPlayer ? 1 : 0).first();
+  return totalsFrom(row);
+}
+
+export async function onRequest({ request, env }) {
+  const database = counterDatabase(env);
+  if (!database) return json({ error: 'counter unavailable' }, 503);
+
+  try {
+    if (request.method === 'GET') {
+      const row = await database.prepare(
+        'SELECT players, plays FROM play_totals WHERE id = 1',
+      ).first();
+      return json(row ? totalsFrom(row) : EMPTY_TOTALS);
+    }
+
+    if (request.method !== 'POST') {
+      return json({ error: 'method not allowed' }, 405);
+    }
+
+    const origin = request.headers.get('origin');
+    if (origin && new URL(origin).host !== new URL(request.url).host) {
+      return json({ error: 'cross-origin' }, 403);
+    }
+
+    let body = null;
+    try {
+      body = await request.json();
+    } catch {
+      body = null;
+    }
+
+    return json(await increment(database, body?.newPlayer === true));
+  } catch {
+    return json({ error: 'counter unavailable' }, 503);
+  }
+}

--- a/migrations/0001_play_counter.sql
+++ b/migrations/0001_play_counter.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS play_totals (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  players INTEGER NOT NULL DEFAULT 0 CHECK (players >= 0),
+  plays INTEGER NOT NULL DEFAULT 0 CHECK (plays >= players)
+);
+
+INSERT OR IGNORE INTO play_totals (id, players, plays) VALUES (1, 0, 0);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Claude of Duty: Vibe Slops II — a browser-based Three.js shooter on the Hijacked map export.",
   "scripts": {
+    "cloudflare:stage": "node .tools/stage_cloudflare.mjs",
+    "cloudflare:dev": "npm run cloudflare:stage && npx wrangler pages dev",
+    "cloudflare:deploy": "npm run cloudflare:stage && npx wrangler pages deploy",
     "ai:game": "node .tools/ai-game.mjs",
     "ai:state": "node .tools/ai-game.mjs state",
     "ai:screenshot": "node .tools/ai-game.mjs screenshot",
@@ -19,7 +22,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/test/cloudflare-play-counter.test.mjs
+++ b/test/cloudflare-play-counter.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  counterDatabase,
+  increment,
+  onRequest,
+  totalsFrom,
+} from '../functions/api/plays.js';
+
+class FakeStatement {
+  constructor(database, query) {
+    this.database = database;
+    this.query = query;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async first() {
+    if (this.query.includes('UPDATE play_totals')) {
+      this.database.totals.players += this.values[0];
+      this.database.totals.plays += 1;
+    }
+    return { ...this.database.totals };
+  }
+}
+
+class FakeDatabase {
+  constructor(players = 0, plays = 0) {
+    this.totals = { players, plays };
+  }
+
+  prepare(query) {
+    return new FakeStatement(this, query);
+  }
+}
+
+function environment(branch = 'preview') {
+  return {
+    CF_PAGES_BRANCH: branch,
+    PLAY_COUNTER: new FakeDatabase(7, 11),
+    PLAY_COUNTER_PREVIEW: new FakeDatabase(2, 3),
+  };
+}
+
+test('totalsFrom sanitizes persisted values', () => {
+  assert.deepEqual(totalsFrom({ players: '4.9', plays: -2 }), { players: 4, plays: 0 });
+  assert.deepEqual(totalsFrom(null), { players: 0, plays: 0 });
+});
+
+test('counterDatabase keeps previews out of production totals', () => {
+  const env = environment('feature-branch');
+  assert.equal(counterDatabase(env), env.PLAY_COUNTER_PREVIEW);
+  env.CF_PAGES_BRANCH = 'main';
+  assert.equal(counterDatabase(env), env.PLAY_COUNTER);
+});
+
+test('increment atomically advances plays and optionally players', async () => {
+  const database = new FakeDatabase(5, 8);
+  assert.deepEqual(await increment(database, true), { players: 6, plays: 9 });
+  assert.deepEqual(await increment(database, false), { players: 6, plays: 10 });
+});
+
+test('GET reads totals and POST increments the selected database', async () => {
+  const env = environment('preview');
+  const getResponse = await onRequest({
+    request: new Request('https://preview.example/api/plays'),
+    env,
+  });
+  assert.equal(getResponse.status, 200);
+  assert.deepEqual(await getResponse.json(), { players: 2, plays: 3 });
+
+  const postResponse = await onRequest({
+    request: new Request('https://preview.example/api/plays', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: 'https://preview.example' },
+      body: JSON.stringify({ newPlayer: true }),
+    }),
+    env,
+  });
+  assert.equal(postResponse.status, 200);
+  assert.deepEqual(await postResponse.json(), { players: 3, plays: 4 });
+  assert.deepEqual(env.PLAY_COUNTER.totals, { players: 7, plays: 11 });
+});
+
+test('POST rejects a cross-origin counter increment', async () => {
+  const response = await onRequest({
+    request: new Request('https://preview.example/api/plays', {
+      method: 'POST',
+      headers: { origin: 'https://other.example' },
+    }),
+    env: environment(),
+  });
+  assert.equal(response.status, 403);
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "claude-of-duty",
+  "compatibility_date": "2026-09-02",
+  "pages_build_output_dir": "./.work/cloudflare-pages",
+  "d1_databases": [
+    {
+      "binding": "PLAY_COUNTER",
+      "database_name": "claude-of-duty-counter",
+      "database_id": "bb28d112-b018-4d5f-97fd-02a97ddebc82",
+      "preview_database_id": "PLAY_COUNTER"
+    },
+    {
+      "binding": "PLAY_COUNTER_PREVIEW",
+      "database_name": "claude-of-duty-counter-preview",
+      "database_id": "1cd90339-44ac-4450-baab-a09478d4a42d",
+      "preview_database_id": "PLAY_COUNTER_PREVIEW"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- stage only runtime assets for Cloudflare Pages
- replace the Netlify play-counter backend with a Pages Function and isolated D1 databases
- document and test the free Cloudflare deployment flow

## Verification
- 160 unit tests pass
- deployed Cloudflare preview passes the full AI gameplay harness
- preview serves the map and the D1 GET/POST counter successfully

Preview: https://cloudflare-hosting.claude-of-duty-bfq.pages.dev

The custom domain remains on Netlify until the preview is approved and production counter totals are selected.