### PR TITLE
Bob the camera with the stride and lean into the sprint

### DIFF
--- a/export/web/index.html
+++ b/export/web/index.html
@@ -593,6 +593,7 @@ import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import { PlayerController } from './player-controller.js';
 import { loadNavigation } from './navigation.js';
 import { Viewmodel } from './viewmodel.js';
+import { ViewBob } from './view-bob.js';
 import { WeaponController } from './weapon-controller.js';
 import { WeaponEffects } from './weapon-effects.js';
 import { EnemyManager } from './enemy-system.js';
@@ -872,6 +873,7 @@ const weaponSlots = new Map(Object.values(WEAPON_DEFINITIONS).map((definition) =
 let activeWeaponId = 'm27';
 let activeWeaponSlot = weaponSlots.get(activeWeaponId);
 let viewmodel = activeWeaponSlot.viewmodel;
+const viewBob = new ViewBob();
 let weapon = null;
 const WEAPON_ALIASES = Object.freeze({ hk416: 'm27' });
 
@@ -2107,6 +2109,12 @@ function tick() {
       sprinting,
       moving,
     });
+    viewBob.update(dt, {
+      speed,
+      grounded: player.isGrounded,
+      sprinting,
+      moving,
+    });
     if (weapon.reloading && !viewmodel.reloading) weapon.finishReload();
     weapon.update(dt, { canFire: simulationActive && !sprinting && !playerHealth?.dead });
 
@@ -2195,7 +2203,11 @@ function tick() {
   updateMedalPopups();
 
   updateLightProbes(camera.position);
+  // The stride bob lives on the camera only for the draw; gameplay reads the
+  // steady camera before and after.
+  viewBob.apply(camera);
   renderFrame();
+  viewBob.restore(camera);
   if (ready && performance.now() >= frameWorkWarmupUntil) {
     frameWorkSamples[frameWorkSampleIndex] = performance.now() - frameWorkStartedAt;
     frameWorkSampleIndex = (frameWorkSampleIndex + 1) % frameWorkSamples.length;

--- a/export/web/view-bob.js
+++ b/export/web/view-bob.js
@@ -1,0 +1,104 @@
+import * as THREE from 'three';
+
+// Camera-space view bob: the stride nudges the eye and rolls it a little,
+// heavier when sprinting. The camera is the gameplay truth for position and
+// aim (the controller writes it, firing and look read it), so the offset is
+// applied around the render only and restored straight after.
+
+const WALK = Object.freeze({
+  // Offsets in world units (inches), rotations in radians, at full walk speed.
+  side: 0.28,
+  rise: 0.36,
+  roll: 0.005,
+  pitch: 0.003,
+});
+
+const SPRINT = Object.freeze({
+  // Multipliers on the walk values as sprintBlend rises. The stride also slows
+  // by `slow`, matching the heavier footfall in the viewmodel bob.
+  side: 2,
+  rise: 1.7,
+  roll: 2.6,
+  pitch: 1.8,
+  slow: 0.45,
+  // Constant lean while sprinting: a small downward pitch reads as pushing
+  // into the run.
+  lean: 0.01,
+});
+
+// Ground contact drops for a few physics steps on every stair riser and lip,
+// so the stride keeps going for this long after the last contact instead of
+// stuttering on terrain.
+const GROUND_GRACE = 0.25;
+
+function damp(current, target, lambda, dt) {
+  return THREE.MathUtils.damp(current, target, lambda, dt);
+}
+
+export class ViewBob {
+  constructor() {
+    this.bobTime = 0;
+    this.bobAmp = 0;
+    this.sprintBlend = 0;
+    this.airTime = 0;
+    this.offset = new THREE.Vector3();
+    this.tilt = new THREE.Euler(0, 0, 0, 'YXZ');
+    this._savedPosition = new THREE.Vector3();
+    this._savedQuaternion = new THREE.Quaternion();
+    this._tiltQuaternion = new THREE.Quaternion();
+    this._worldOffset = new THREE.Vector3();
+    this._applied = false;
+  }
+
+  update(dt, state = {}) {
+    const speed = state.speed ?? 0;
+    const grounded = state.grounded ?? true;
+    const moving = Boolean(state.moving);
+    const sprinting = Boolean(state.sprinting) && moving;
+
+    this.sprintBlend = damp(this.sprintBlend, sprinting ? 1 : 0, 8, dt);
+    const sprint = this.sprintBlend;
+
+    // Same stride clock as the viewmodel bob so the gun and the eye agree.
+    this.airTime = grounded ? 0 : this.airTime + dt;
+    const movingGrounded = moving && this.airTime < GROUND_GRACE;
+    const speedFactor = THREE.MathUtils.clamp(speed / 300, 0, 1.4);
+    this.bobAmp = damp(this.bobAmp, movingGrounded ? speedFactor : 0, 8, dt);
+    if (movingGrounded) this.bobTime += dt * (5.5 + 4 * speedFactor) * (1 - SPRINT.slow * sprint);
+
+    const stride = Math.sin(this.bobTime);
+    const step = Math.sin(this.bobTime * 2);
+    const amp = this.bobAmp;
+    const lerp = (walk, sprintScale) => walk * (1 + (sprintScale - 1) * sprint);
+
+    this.offset.set(
+      stride * lerp(WALK.side, SPRINT.side) * amp,
+      // Footfalls dip rather than lift, so the rise is biased downward.
+      (step - 0.5) * lerp(WALK.rise, SPRINT.rise) * amp,
+      0,
+    );
+    this.tilt.set(
+      step * lerp(WALK.pitch, SPRINT.pitch) * amp - SPRINT.lean * sprint,
+      0,
+      stride * lerp(WALK.roll, SPRINT.roll) * amp,
+    );
+  }
+
+  // Push the bob onto the camera for a render. Call restore() afterwards.
+  apply(camera) {
+    if (this._applied) return;
+    this._savedPosition.copy(camera.position);
+    this._savedQuaternion.copy(camera.quaternion);
+    this._applied = true;
+    camera.position.add(this._worldOffset.copy(this.offset).applyQuaternion(camera.quaternion));
+    this._tiltQuaternion.setFromEuler(this.tilt);
+    camera.quaternion.multiply(this._tiltQuaternion);
+  }
+
+  restore(camera) {
+    if (!this._applied) return;
+    camera.position.copy(this._savedPosition);
+    camera.quaternion.copy(this._savedQuaternion);
+    this._applied = false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/test/view-bob.test.mjs
+++ b/test/view-bob.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as THREE from 'three';
+import { ViewBob } from '../export/web/view-bob.js';
+
+function settle(bob, state, seconds = 2) {
+  for (let t = 0; t < seconds; t += 1 / 60) bob.update(1 / 60, state);
+}
+
+test('standing still leaves the camera untouched', () => {
+  const bob = new ViewBob();
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.set(10, 60, -5);
+  camera.quaternion.setFromEuler(new THREE.Euler(0.2, 1.1, 0, 'YXZ'));
+  settle(bob, { speed: 0, moving: false, grounded: true });
+  const position = camera.position.clone();
+  const quaternion = camera.quaternion.clone();
+  bob.apply(camera);
+  assert.ok(camera.position.distanceTo(position) < 1e-6);
+  assert.ok(Math.abs(camera.quaternion.angleTo(quaternion)) < 1e-6);
+  bob.restore(camera);
+});
+
+test('walking bobs the camera and restore puts it back exactly', () => {
+  const bob = new ViewBob();
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.set(0, 60, 0);
+  camera.quaternion.setFromEuler(new THREE.Euler(0, 0.7, 0, 'YXZ'));
+  const position = camera.position.clone();
+  const quaternion = camera.quaternion.clone();
+  let moved = false;
+  for (let i = 0; i < 60; i += 1) {
+    bob.update(1 / 60, { speed: 300, moving: true, grounded: true });
+    bob.apply(camera);
+    if (camera.position.distanceTo(position) > 0.05) moved = true;
+    bob.restore(camera);
+    assert.deepEqual(camera.position.toArray(), position.toArray());
+    assert.deepEqual(camera.quaternion.toArray(), quaternion.toArray());
+  }
+  assert.ok(moved, 'walk stride should displace the rendered eye');
+});
+
+test('sprinting swings harder and leans in, and airborne stride fades', () => {
+  const walk = new ViewBob();
+  settle(walk, { speed: 300, moving: true, grounded: true });
+  const sprint = new ViewBob();
+  settle(sprint, { speed: 450, moving: true, sprinting: true, grounded: true });
+  assert.ok(sprint.sprintBlend > 0.99);
+  assert.ok(sprint.tilt.x < 0, 'sprint should pitch the eye down slightly');
+  let walkPeak = 0;
+  let sprintPeak = 0;
+  for (let i = 0; i < 120; i += 1) {
+    walk.update(1 / 60, { speed: 300, moving: true, grounded: true });
+    sprint.update(1 / 60, { speed: 450, moving: true, sprinting: true, grounded: true });
+    walkPeak = Math.max(walkPeak, Math.abs(walk.offset.x));
+    sprintPeak = Math.max(sprintPeak, Math.abs(sprint.offset.x));
+  }
+  assert.ok(sprintPeak > walkPeak * 1.5);
+
+  settle(sprint, { speed: 450, moving: true, sprinting: true, grounded: false });
+  assert.ok(sprint.bobAmp < 0.01, 'airborne stride should fade out');
+});
+
+test('apply is idempotent until restored', () => {
+  const bob = new ViewBob();
+  const camera = new THREE.PerspectiveCamera();
+  settle(bob, { speed: 300, moving: true, grounded: true }, 0.5);
+  bob.apply(camera);
+  const once = camera.position.clone();
+  bob.apply(camera);
+  assert.deepEqual(camera.position.toArray(), once.toArray());
+  bob.restore(camera);
+  assert.deepEqual(camera.position.toArray(), [0, 0, 0]);
+});
+
+test('a brief loss of ground contact, as on a stair riser, does not stop the stride', () => {
+  const bob = new ViewBob();
+  settle(bob, { speed: 300, moving: true, grounded: true });
+  const before = bob.bobAmp;
+  for (let i = 0; i < 6; i += 1) bob.update(1 / 60, { speed: 300, moving: true, grounded: false });
+  assert.ok(Math.abs(bob.bobAmp - before) < 1e-6, 'six airborne frames should not touch the stride');
+  settle(bob, { speed: 300, moving: true, grounded: false }, 1);
+  assert.ok(bob.bobAmp < 0.01, 'a real jump still fades the stride');
+});


### PR DESCRIPTION
Follow-up to #9. Even with the gun pose fixed, running still felt like a hyperglide across the map because the camera itself never moves. BO2 bobs the view on every stride and leans into the sprint.

### What changed

- New `export/web/view-bob.js`. The stride nudges the eye sideways, dips it on each footfall, and rolls it slightly. Sprinting swings about twice as hard with a small forward lean. Airborne, it fades out.
- The bob keeps going for a quarter second after ground contact drops, because contact flickers on every stair riser and lip and the stride was stopping on stairs.
- It runs on the same stride clock as the gun bob so the eye and the weapon agree.
- The offset is applied to the camera only around the render and restored right after. Firing, mouse look, the audio listener, and the player controller all read the steady camera, so aim is untouched.

Tuning lives in the `WALK` and `SPRINT` constants at the top of `view-bob.js`.

### Checks

- `npm run test:unit`: 143 pass, 0 fail (5 new in `test/view-bob.test.mjs`)
- `npm run ai:test`: boots and fires with no console errors
- Tested by hand in Chrome: walk, sprint, stairs, jumps. A still doesn't show camera motion, so no screenshot.
