### PR TITLE
Keep the weapon bob going across stair risers

### DIFF
--- a/export/web/viewmodel.js
+++ b/export/web/viewmodel.js
@@ -30,6 +30,8 @@ const MAGAZINE_TAGS = Object.freeze(new Set(['tag_clip', ...SPARE_MAGAZINE_TAGS]
 // The cue the clips fire as the empty magazine is released, which is the instant
 // the fresh one takes over as the magazine the reload is about; see
 // handOverMagazine().
+const BOB_GROUND_GRACE = 0.25;
+
 const MAGAZINE_HANDOVER_CUE = /mag_out/;
 // The red tritium insert capping the front post is the element the eye lines up
 // on, so it defines where the sight picture points, not the tag authored on the
@@ -134,6 +136,7 @@ export class Viewmodel {
     this.sprintBlend = 0;
     this.bobTime = 0;
     this.bobAmp = 0;
+    this.airTime = 0;
     this.pendingLook = new THREE.Vector2();
     this.lookVel = new THREE.Vector2();
     this.swayRot = new THREE.Vector2();
@@ -783,8 +786,11 @@ export class Viewmodel {
     this.swayPos.x = damp(this.swayPos.x, clamp(-this.lookVel.x * 0.004, -1.2, 1.2), 10, dt);
     this.swayPos.y = damp(this.swayPos.y, clamp(this.lookVel.y * 0.004, -1.2, 1.2), 10, dt);
 
-    // Walk bob: figure-eight drift scaled by ground speed.
-    const movingGrounded = moving && grounded;
+    // Walk bob: figure-eight drift scaled by ground speed. Ground contact
+    // drops for a few physics steps on every stair riser and lip, so the
+    // stride carries on briefly after the last contact instead of hitching.
+    this.airTime = grounded ? 0 : this.airTime + dt;
+    const movingGrounded = moving && this.airTime < BOB_GROUND_GRACE;
     const speedFactor = clamp(speed / 300, 0, 1.4);
     this.bobAmp = damp(this.bobAmp, movingGrounded ? speedFactor : 0, 8, dt);
     if (movingGrounded) this.bobTime += dt * (5.5 + 4 * speedFactor);

--- a/test/viewmodel-ads.test.mjs
+++ b/test/viewmodel-ads.test.mjs
@@ -310,3 +310,15 @@ for (const { id, sightTag, insert, adsSightAnchors } of RIFLE_SIGHT_CONFIGS) {
     }
   });
 }
+
+test('a brief loss of ground contact, as on a stair riser, does not stop the walk bob', () => {
+  const viewmodel = new Viewmodel();
+  viewmodel.ready = true;
+  const walk = { speed: 300, moving: true, grounded: true };
+  for (let i = 0; i < 120; i += 1) viewmodel.update(1 / 60, walk);
+  const before = viewmodel.bobAmp;
+  for (let i = 0; i < 6; i += 1) viewmodel.update(1 / 60, { ...walk, grounded: false });
+  assert.ok(Math.abs(viewmodel.bobAmp - before) < 1e-6, 'six airborne frames should not touch the stride');
+  for (let i = 0; i < 60; i += 1) viewmodel.update(1 / 60, { ...walk, grounded: false });
+  assert.ok(viewmodel.bobAmp < 0.01, 'a real jump still fades the stride');
+});


### PR DESCRIPTION
Small one. The gun's walk bob stops on stairs and other uneven terrain because ground contact drops for a few physics steps on every riser and lip, and the bob damps out each time. The stride now keeps going for a quarter second after the last contact. A real jump still fades it out.

Same fix as the camera bob in #10, applied to `viewmodel.js`. Independent of #10. It touches the same bob lines in `viewmodel.js` as #9, so whichever of the two lands second needs a small rebase; happy to do that.

- `npm run test:unit`: 139 pass, 0 fail (1 new)
- `npm run ai:test`: no console errors
