### PR TITLE
Stop the teak deck shimmering and corpses planting through the floor

### DIFF
--- a/export/web/death-camera.js
+++ b/export/web/death-camera.js
@@ -1,0 +1,31 @@
+import * as THREE from 'three';
+
+const _euler = new THREE.Euler(0, 0, 0, 'YXZ');
+
+// Keep the kill look on the killer without pitching the eye into the deck
+// when they are standing on top of the body.
+const MAX_PITCH = 0.55;
+
+/**
+ * Aim the first-person camera at a killer. Pitch is clamped so a close
+ * attacker at torso height cannot bury the view in the floor.
+ */
+export function aimDeathCamera(camera, eye, target, { maxPitch = MAX_PITCH } = {}) {
+  if (!camera || !eye || !target) return camera;
+  const dx = target.x - eye.x;
+  const dy = target.y - eye.y;
+  const dz = target.z - eye.z;
+  const horiz = Math.hypot(dx, dz);
+  if (horiz < 1e-5 && Math.abs(dy) < 1e-5) return camera;
+  const yaw = Math.atan2(-dx, -dz);
+  const pitch = THREE.MathUtils.clamp(
+    Math.atan2(dy, Math.max(horiz, 1e-4)),
+    -maxPitch,
+    maxPitch,
+  );
+  _euler.set(pitch, yaw, 0, 'YXZ');
+  camera.quaternion.setFromEuler(_euler);
+  return camera;
+}
+
+export default aimDeathCamera;

--- a/export/web/enemy-system.js
+++ b/export/web/enemy-system.js
@@ -23,6 +23,13 @@ function planarDistance(a, b) {
   return Math.hypot(a.x - b.x, a.z - b.z);
 }
 
+// pb_death_faceplant already rotates the authored body onto the navmesh.
+// A second root roll (~77°) plus a 10-inch sink drove the torso through
+// the deck, so the corpse read as planted in the floor.
+export function deathRootPose(_blend = 1) {
+  return { rotationZ: 0, positionY: 0 };
+}
+
 function dampAngle(current, target, lambda, dt) {
   const delta = Math.atan2(Math.sin(target - current), Math.cos(target - current));
   return current + delta * (1 - Math.exp(-lambda * dt));
@@ -741,8 +748,9 @@ class Enemy {
       if (!active) return;
       this.advanceVisual(dt);
       this.deathBlend = Math.min(1, this.deathBlend + dt * 2.8);
-      this.modelRoot.rotation.z = -this.deathBlend * 1.35;
-      this.modelRoot.position.y = -this.deathBlend * 10;
+      const pose = deathRootPose(this.deathBlend);
+      this.modelRoot.rotation.z = pose.rotationZ;
+      this.modelRoot.position.y = pose.positionY;
       this.respawnTimer -= dt;
       if (this.respawnTimer <= 0) this.spawnAt(this.manager.respawnFor(this));
       return;

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -605,14 +605,17 @@ import { Frontend } from './frontend.js';
 import { PlayCounter } from './play-counter.js';
 import { loadCollisionWorld } from './collision-world.js';
 import { optimizeStaticScene } from './scene-optimizer.js';
-import { applyEnvironmentLighting, loadGradeLut, POST_SHADER, HAZE, applyMaterialClasses } from './lighting.js';
+import { applyEnvironmentLighting, loadGradeLut, POST_SHADER, HAZE, applyMaterialClasses, applyTextureAnisotropy } from './lighting.js';
+import { aimDeathCamera } from './death-camera.js';
 import { loadProbeVolume, attachObjectProbe } from './light-probes.js';
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x87a8c8);
 scene.fog = new THREE.Fog(0x87a8c8, HAZE.near, HAZE.far);
 
-const camera = new THREE.PerspectiveCamera(75, innerWidth / innerHeight, 1, 20000);
+// Far is just beyond the map diagonal (~6.6k) and the haze far plane.
+// 20k wasted depth precision and made the teak deck z-fight as you walked.
+const camera = new THREE.PerspectiveCamera(75, innerWidth / innerHeight, 1, 10000);
 camera.rotation.order = 'YXZ';
 
 const MAX_RENDER_PIXELS = 1600 * 900;
@@ -1450,6 +1453,9 @@ function loadGltf(url, label) {
     if (gltf.scene) {
       const reclassified = applyMaterialClasses(gltf.scene);
       if (reclassified) console.info(`${label}: reclassified ${reclassified} materials`);
+      const anisotropy = Math.min(16, renderer.capabilities.getMaxAnisotropy() || 1);
+      const filtered = applyTextureAnisotropy(gltf.scene, anisotropy);
+      if (filtered) console.info(`${label}: anisotropy ${anisotropy} on ${filtered} textures`);
     }
     frontend.stage(label);
     return gltf;
@@ -2110,19 +2116,19 @@ function tick() {
       moving,
     });
     viewBob.update(dt, {
-      speed,
+      speed: playerHealth?.dead ? 0 : speed,
       grounded: player.isGrounded,
-      sprinting,
-      moving,
+      sprinting: Boolean(sprinting) && !playerHealth?.dead,
+      moving: Boolean(moving) && !playerHealth?.dead,
     });
     if (weapon.reloading && !viewmodel.reloading) weapon.finishReload();
     weapon.update(dt, { canFire: simulationActive && !sprinting && !playerHealth?.dead });
 
     if (playerHealth?.dead) {
       const sourcePosition = Number.isInteger(deathSource?.index) && !deathSource.dead
-        ? enemies?.targetPosition(deathSource)
+        ? deathSource.eyePosition?.() ?? enemies?.targetPosition(deathSource)
         : null;
-      if (sourcePosition) camera.lookAt(sourcePosition);
+      if (sourcePosition) aimDeathCamera(camera, camera.position, sourcePosition);
       const sourceEntry = match.getState().standings.find((entry) => entry.id === combatantId(deathSource));
       deathKiller.textContent = sourceEntry ? `Killed by ${sourceEntry.name}` : 'Killed in action';
       respawnCopy.textContent = `Respawning in ${Math.max(0, playerHealth.respawnTimer).toFixed(1)} seconds`;

--- a/export/web/lighting.js
+++ b/export/web/lighting.js
@@ -282,6 +282,35 @@ export function applyMaterialClasses(root) {
   return changed;
 }
 
+const TEXTURE_SLOTS = ['map', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap'];
+
+/**
+ * Raise anisotropy on unique textures in a loaded subtree.
+ * Grazing teak decking shimmers without it because the map is all
+ * high-frequency wood grain viewed at a shallow angle.
+ */
+export function applyTextureAnisotropy(root, anisotropy) {
+  const amount = Math.max(1, Number(anisotropy) || 1);
+  if (!root?.traverse) return 0;
+  const seen = new Set();
+  let changed = 0;
+  root.traverse((object) => {
+    if (!object.isMesh && !object.isSkinnedMesh) return;
+    const list = Array.isArray(object.material) ? object.material : [object.material];
+    for (const material of list) {
+      if (!material) continue;
+      for (const slot of TEXTURE_SLOTS) {
+        const texture = material[slot];
+        if (!texture || seen.has(texture)) continue;
+        seen.add(texture);
+        texture.anisotropy = amount;
+        changed += 1;
+      }
+    }
+  });
+  return changed;
+}
+
 /**
  * Turn the vision set's tone targets into post-pass uniforms.
  *

--- a/export/web/player-controller.js
+++ b/export/web/player-controller.js
@@ -524,6 +524,12 @@ export class PlayerController {
       this.onFloor = groundedDuringMove;
       this.grounded = groundedDuringMove;
       if (groundedDuringMove && this.velocity.y < 0) this.velocity.y = 0;
+      // Collision overlap order on overlapping deck triangles chatters the
+      // capsule by a fraction of an inch. Snap the feet to the floor under
+      // them so the eye (and the teak texture) stay still.
+      if (groundedDuringMove && this.velocity.y <= this.maxGroundProbeRiseSpeed) {
+        this._snapToGround();
+      }
     }
 
     if (this.fallResetY !== null && this.collider.start.y - this.radius < this.fallResetY) {
@@ -788,8 +794,8 @@ export class PlayerController {
    * into a wall-heavy normal. A short vertical ray avoids treating that as a
    * lost floor while still requiring actual geometry directly below the feet.
    */
-  _probeGround() {
-    if (!this.worldReady || typeof this.worldOctree.rayIntersect !== 'function') return false;
+  _groundHit() {
+    if (!this.worldReady || typeof this.worldOctree.rayIntersect !== 'function') return null;
 
     const feetY = this.collider.start.y - this.radius;
     _groundOrigin.set(
@@ -799,11 +805,29 @@ export class PlayerController {
     );
     _groundRay.origin.copy(_groundOrigin);
     const hit = this.worldOctree.rayIntersect(_groundRay);
-    if (!hit || hit.distance > this.groundProbeDistance + this.skin * 2) return false;
+    // Allow a little extra reach so resolver chatter still finds the deck.
+    if (!hit || hit.distance > this.groundProbeDistance + 1) return null;
 
     hit.triangle.getNormal(_normal);
-    if (_normal.y < this.floorNormalY) return false;
+    if (_normal.y < this.floorNormalY) return null;
     this._collisionNormal.copy(_normal);
+    return hit.position ?? hit.point ?? null;
+  }
+
+  _probeGround() {
+    return Boolean(this._groundHit());
+  }
+
+  _snapToGround() {
+    const point = this._groundHit();
+    if (!point) return false;
+    // Raw hit Y is only a legal rest height on near-flat floors. On a slope
+    // it embeds the bottom sphere by radius*(1/ny - 1) and fights the resolver.
+    if (this._collisionNormal.y < 0.995) return false;
+    const delta = point.y - (this.collider.start.y - this.radius);
+    if (Math.abs(delta) > this.groundProbeDistance) return false;
+    this.collider.start.y += delta;
+    this.collider.end.y += delta;
     return true;
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/enemy-death.test.mjs test/death-camera.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/test/death-camera.test.mjs
+++ b/test/death-camera.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as THREE from 'three';
+import { aimDeathCamera } from '../export/web/death-camera.js';
+
+function pitchFrom(camera) {
+  const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion);
+  const horiz = Math.hypot(forward.x, forward.z);
+  return Math.atan2(forward.y, Math.max(horiz, 1e-8));
+}
+
+test('a close killer does not pitch the death camera into the floor', () => {
+  const camera = new THREE.PerspectiveCamera();
+  camera.rotation.order = 'YXZ';
+  camera.position.set(0, 60, 0);
+
+  // Killer standing almost on top of the player, torso well below the eye.
+  aimDeathCamera(camera, camera.position, new THREE.Vector3(8, 42, 3));
+
+  const pitch = pitchFrom(camera);
+  assert.ok(pitch > -0.7, `death cam pitched into the deck: ${pitch}`);
+  assert.ok(pitch < 0.7, `death cam pitched into the sky: ${pitch}`);
+});
+
+test('death camera looks toward the killer on the horizontal', () => {
+  const camera = new THREE.PerspectiveCamera();
+  camera.rotation.order = 'YXZ';
+  camera.position.set(0, 60, 0);
+  aimDeathCamera(camera, camera.position, new THREE.Vector3(0, 61, -200));
+
+  const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion);
+  assert.ok(forward.z < -0.9, `expected to look down -Z, got ${forward.toArray()}`);
+  assert.ok(Math.abs(forward.y) < 0.15, `level killer should not tilt the view: y=${forward.y}`);
+});
+
+test('missing killer leaves the camera where it was', () => {
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.set(10, 60, -4);
+  camera.quaternion.setFromEuler(new THREE.Euler(-0.2, 1.1, 0, 'YXZ'));
+  const quaternion = camera.quaternion.clone();
+  aimDeathCamera(camera, camera.position, null);
+  assert.deepEqual(camera.quaternion.toArray(), quaternion.toArray());
+});

--- a/test/enemy-death.test.mjs
+++ b/test/enemy-death.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as THREE from 'three';
+import { deathRootPose } from '../export/web/enemy-system.js';
+
+test('the faceplant clip plants the body; death blend does not bury it in the floor', () => {
+  // pb_death_faceplant already rotates the authored body onto the navmesh.
+  // Extra root roll plus a 10-inch sink drives the torso through the deck.
+  const start = deathRootPose(0);
+  const end = deathRootPose(1);
+
+  assert.equal(start.rotationZ, 0);
+  assert.equal(start.positionY, 0);
+  assert.equal(end.rotationZ, 0);
+  assert.equal(end.positionY, 0);
+  assert.ok(Math.abs(end.rotationZ) < 0.2, `death root roll ${end.rotationZ} would swing the body into the floor`);
+  assert.ok(end.positionY > -2, `death root sink ${end.positionY} would bury the corpse`);
+});
+
+test('deathRootPose can be applied to a model root without leaving it underground', () => {
+  const root = new THREE.Group();
+  const pose = deathRootPose(1);
+  root.rotation.z = pose.rotationZ;
+  root.position.y = pose.positionY;
+  assert.equal(root.rotation.z, 0);
+  assert.equal(root.position.y, 0);
+});

--- a/test/lighting.test.mjs
+++ b/test/lighting.test.mjs
@@ -196,6 +196,24 @@ test('material classes make chrome metallic and leave dielectrics alone', async 
   assert.equal(classifyMaterial(undefined), null);
 });
 
+test('world textures get anisotropic filtering so grazing floors do not shimmer', async () => {
+  const { applyTextureAnisotropy } = await import('../export/web/lighting.js');
+  const { Texture, Mesh, MeshStandardMaterial, PlaneGeometry, Group } = await import('three');
+
+  const map = new Texture();
+  const shared = new Texture();
+  const a = new Mesh(new PlaneGeometry(1, 1), new MeshStandardMaterial({ map, name: 'wpc/wood_teak_decking_dark' }));
+  const b = new Mesh(new PlaneGeometry(1, 1), new MeshStandardMaterial({ map: shared, name: 'wpc/wood_teak_decking_light' }));
+  const c = new Mesh(new PlaneGeometry(1, 1), new MeshStandardMaterial({ map: shared, name: 'wpc/ny_nyse_wood_floor_01' }));
+  const root = new Group();
+  root.add(a, b, c);
+
+  const changed = applyTextureAnisotropy(root, 8);
+  assert.equal(changed, 2, 'each unique texture is visited once');
+  assert.equal(map.anisotropy, 8);
+  assert.equal(shared.anisotropy, 8);
+});
+
 test('encodePng writes a decodable image with the expected pixels', () => {
   const w = 3, h = 2;
   const rgb = Buffer.from([

--- a/test/player-controller.test.mjs
+++ b/test/player-controller.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { test } from 'node:test';
 import * as THREE from 'three';
+import { deserializeCollisionWorld } from '../export/web/collision-world.js';
 import { PlayerController } from '../export/web/player-controller.js';
 
 test('capsule stops at a wall without gaining launch velocity', () => {
@@ -180,6 +183,130 @@ test('a climb blocked by geometry lets go instead of hanging', () => {
   assert.ok(
     player.feetPosition.y < 40,
     `expected to be stopped under the overhang: y=${player.feetPosition.y}`,
+  );
+});
+
+test('strafing the Hijacked deck does not chatter the eye through the teak', () => {
+  const repo = path.join(import.meta.dirname, '..');
+  const metadata = JSON.parse(fs.readFileSync(path.join(repo, 'export/web/hijacked_collision_bvh.json'), 'utf8'));
+  const file = fs.readFileSync(path.join(repo, 'export/web/hijacked_collision_bvh.bin'));
+  const binary = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+  const world = deserializeCollisionWorld(metadata, binary);
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, world, {
+    spawn: new THREE.Vector3(2102, 57, 133),
+    radius: 16,
+    height: 72,
+    eyeHeight: 60,
+    moveSpeed: 300,
+    maxSlopeAngle: 45,
+  });
+
+  for (let i = 0; i < 60; i += 1) player.update(1 / 120, {});
+  let previous = player.position.y;
+  let maxStep = 0;
+  const eyes = [];
+  for (let i = 0; i < 360; i += 1) {
+    player.update(1 / 120, { strafe: Math.sin(i / 20) });
+    const y = player.position.y;
+    maxStep = Math.max(maxStep, Math.abs(y - previous));
+    eyes.push(y);
+    previous = y;
+  }
+  const span = Math.max(...eyes) - Math.min(...eyes);
+  assert.ok(player.isGrounded, 'player left the deck');
+  assert.ok(
+    maxStep < 0.04,
+    `deck chatter ${maxStep.toFixed(3)} in/step would shimmer the floor texture`,
+  );
+  assert.ok(
+    span < 0.08,
+    `eye Y wandered ${span.toFixed(3)} while strafing a flat deck patch`,
+  );
+});
+
+test('ground snap does not embed the capsule in a walkable ramp', () => {
+  const angle = THREE.MathUtils.degToRad(15);
+  const length = 800;
+  const rise = Math.tan(angle) * length;
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    -200, 0, 0,
+    200, 0, 0,
+    200, rise, -length,
+    -200, 0, 0,
+    200, rise, -length,
+    -200, rise, -length,
+  ], 3));
+  geometry.computeVertexNormals();
+  const world = new THREE.Group();
+  world.add(new THREE.Mesh(geometry));
+  world.updateWorldMatrix(true, true);
+
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, world, {
+    spawn: new THREE.Vector3(0, 0.2, -20),
+    radius: 16,
+    height: 72,
+    eyeHeight: 60,
+    moveSpeed: 300,
+    maxSlopeAngle: 45,
+  });
+
+  let minClearance = Infinity;
+  let groundedFrames = 0;
+  for (let i = 0; i < 180; i += 1) {
+    player.update(1 / 120, { forward: true });
+    if (!player.isGrounded) continue;
+    groundedFrames += 1;
+    const hit = player.worldOctree.rayIntersect(
+      new THREE.Ray(
+        new THREE.Vector3(player.collider.start.x, player.collider.start.y + 8, player.collider.start.z),
+        new THREE.Vector3(0, -1, 0),
+      ),
+    );
+    if (!hit) continue;
+    const normal = hit.triangle.getNormal(new THREE.Vector3());
+    const point = hit.position ?? hit.point;
+    minClearance = Math.min(minClearance, player.collider.start.clone().sub(point).dot(normal));
+  }
+
+  assert.ok(groundedFrames > 30, `never walked the ramp: grounded ${groundedFrames} frames`);
+  assert.ok(
+    minClearance >= player.radius - 0.25,
+    `snap buried the capsule in the ramp: clearance ${minClearance.toFixed(3)} vs radius ${player.radius}`,
+  );
+});
+
+test('walking a layered floor does not bounce the eye up and down', () => {
+  // Hijacked's deck is overlapping BSP + xmodel triangles a fraction of an
+  // inch apart. A large downward snap that then fights the resolver makes the
+  // camera Y chatter, which reads as the floor texture shaking.
+  const world = new THREE.Group();
+  const floorA = new THREE.Mesh(new THREE.BoxGeometry(2000, 1, 2000));
+  floorA.position.y = -0.5;
+  const floorB = new THREE.Mesh(new THREE.BoxGeometry(2000, 1, 2000));
+  floorB.position.y = -0.45;
+  world.add(floorA, floorB);
+  world.updateWorldMatrix(true, true);
+
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, world, {
+    spawn: new THREE.Vector3(0, 0.2, 0),
+    moveSpeed: 300,
+  });
+
+  const eyes = [];
+  for (let i = 0; i < 360; i += 1) {
+    player.update(1 / 120, { forward: true });
+    if (i >= 120) eyes.push(player.position.y);
+  }
+  const span = Math.max(...eyes) - Math.min(...eyes);
+  assert.ok(player.isGrounded, 'player left the floor');
+  assert.ok(
+    span < 0.2,
+    `camera Y jittered by ${span.toFixed(3)} while walking a layered floor; ` +
+      `y=${player.position.y} feet=${player.feetPosition.y}`,
   );
 });
 


### PR DESCRIPTION
Two bugs that show up as soon as you play Hijacked.

### Floor texture shaking

Walking the teak deck made the wood grain swim. Three things stacked:

- Overlapping BSP triangles chattered the capsule by a fraction of an inch, so the eye bounced.
- World textures had no anisotropic filtering, and the deck is all high-frequency grain at a grazing angle.
- The camera far plane was 20,000 on a map whose diagonal is about 6,600, which wasted depth precision and z-fought the deck as you moved.

The feet now snap to a downward ray, but only on near-flat floors so a 15° ramp is left to the collision resolver. Textures get anisotropy 16. Far plane is 10,000.

### Planted in the floor on death

`pb_death_faceplant` already plants the body on the navmesh. Death then added a second ~77° root roll and a 10-inch sink, which drove the torso through the deck. A close killer made it worse: `camera.lookAt` aimed at their torso (42" up) from the eye (60"), so standing on the body pitched the view into the floor.

Death now leaves the root pose alone and aims at the killer's eyes with the pitch clamped.

### Checks

- `npm run test:unit`: 158 pass, 0 fail (8 new)
- `npm run ai:test`: ready, moved, fired, six enemies, no console errors
- `npm run ai:life`: death state, respawn, loadout restore, no console errors