### PR TITLE
Ask for a callsign on the title screen and keep it locally

### DIFF
--- a/export/web/index.html
+++ b/export/web/index.html
@@ -1229,7 +1229,9 @@ const MEDAL_HOLD_SECONDS = 2.1;
 const MEDAL_FADE_SECONDS = 0.45;
 
 const match = new FreeForAllMatch({ scoreLimit: 30, timeLimitSeconds: 300 });
-const playerName = new PlayerName({ storage: localStorage });
+const playerName = new PlayerName({
+  storage: (() => { try { return window.localStorage; } catch { return null; } })(),
+});
 const callsignInput = document.getElementById('fe-callsign');
 const callsignWrap = document.getElementById('fe-callsign-wrap');
 function applyCallsign(value = callsignInput?.value) {
@@ -1874,9 +1876,12 @@ document.addEventListener('contextmenu', (event) => {
 });
 
 document.addEventListener('keydown', (event) => {
-  keys[event.code] = true;
-  if (['Space', 'Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.code)) {
-    event.preventDefault();
+  const typing = event.target instanceof HTMLInputElement;
+  if (!typing) {
+    keys[event.code] = true;
+    if (['Space', 'Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.code)) {
+      event.preventDefault();
+    }
   }
   if (event.repeat || !ready) return;
   if (event.code === 'Enter' && match.phase === 'ended') {
@@ -1886,7 +1891,7 @@ document.addEventListener('keydown', (event) => {
   // Any key but Esc starts or resumes from the shell — Esc is what released
   // the pointer lock to get here, and the browser owns it for a moment after.
   if (frontend.visible) {
-    if (event.target instanceof HTMLInputElement) {
+    if (typing) {
       if (event.code === 'Enter') {
         event.preventDefault();
         applyCallsign(event.target.value);

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -155,6 +155,34 @@
   .fe-start-foot {
     display: flex; flex-direction: column; align-items: center; gap: 10px;
   }
+  .fe-callsign {
+    position: relative; display: flex; flex-direction: column;
+    align-items: center; gap: 6px; width: 258px;
+  }
+  .fe-callsign span {
+    font-size: 10px; letter-spacing: .3em; text-indent: .3em;
+    text-transform: uppercase; color: rgba(206, 224, 240, .62);
+  }
+  .fe-callsign input {
+    appearance: none; box-sizing: border-box; width: 100%; height: 34px;
+    border: 0; padding: 0 12px; background: none; color: #e6f2ff;
+    font: 600 12px/34px var(--fe-ui); font-stretch: condensed;
+    letter-spacing: .24em; text-align: center; text-transform: uppercase;
+    outline: none;
+  }
+  .fe-callsign input::placeholder { color: rgba(206, 224, 240, .42); }
+  .fe-callsign::before {
+    content: ''; position: absolute; inset: 18px 0 0; z-index: -1;
+    -webkit-mask: url('ui/menu_button_backing.png') center/100% 100% no-repeat;
+    mask: url('ui/menu_button_backing.png') center/100% 100% no-repeat;
+    background: rgba(139, 173, 198, .26);
+  }
+  .fe-callsign:focus-within::before {
+    -webkit-mask-image: url('ui/menu_button_backing_highlight.png');
+    mask-image: url('ui/menu_button_backing_highlight.png');
+    background: var(--fe-accent);
+  }
+  .fe-callsign:focus-within input { color: #04140d; }
 
   .fe-heading {
     margin: 0; font-size: 20px; font-weight: 600; letter-spacing: .38em;
@@ -488,6 +516,10 @@
         <figcaption>mp_hijacked</figcaption>
       </figure>
       <div class="fe-start-foot">
+        <label class="fe-callsign" id="fe-callsign-wrap">
+          <span>Callsign</span>
+          <input id="fe-callsign" type="text" maxlength="16" placeholder="YOU" autocomplete="nickname" spellcheck="false" enterkeyhint="done">
+        </label>
         <p class="fe-prompt">Click to play</p>
         <button type="button" class="fe-btn" data-action="class">Create a class</button>
         <p class="fe-count" id="fe-count" hidden></p>
@@ -603,6 +635,7 @@ import { MedalTracker } from './medals.js';
 import { Hud } from './hud.js';
 import { Frontend } from './frontend.js';
 import { PlayCounter } from './play-counter.js';
+import { PlayerName } from './player-name.js';
 import { loadCollisionWorld } from './collision-world.js';
 import { optimizeStaticScene } from './scene-optimizer.js';
 import { applyEnvironmentLighting, loadGradeLut, POST_SHADER, HAZE, applyMaterialClasses } from './lighting.js';
@@ -1196,7 +1229,28 @@ const MEDAL_HOLD_SECONDS = 2.1;
 const MEDAL_FADE_SECONDS = 0.45;
 
 const match = new FreeForAllMatch({ scoreLimit: 30, timeLimitSeconds: 300 });
-match.register('player', 'YOU', { human: true });
+const playerName = new PlayerName({ storage: localStorage });
+const callsignInput = document.getElementById('fe-callsign');
+const callsignWrap = document.getElementById('fe-callsign-wrap');
+function applyCallsign(value = callsignInput?.value) {
+  const name = playerName.set(value);
+  if (callsignInput) {
+    const typed = String(callsignInput.value ?? '').trim();
+    if (!typed) callsignInput.value = '';
+    else if (callsignInput.value !== name) callsignInput.value = name;
+  }
+  match.register('player', name, { human: true });
+  return name;
+}
+if (callsignInput) {
+  callsignInput.value = playerName.display === 'YOU' ? '' : playerName.display;
+  const stopPlay = (event) => event.stopPropagation();
+  callsignWrap?.addEventListener('click', stopPlay);
+  callsignInput.addEventListener('pointerdown', stopPlay);
+  callsignInput.addEventListener('change', () => applyCallsign());
+  callsignInput.addEventListener('blur', () => applyCallsign());
+}
+applyCallsign(playerName.display);
 
 const weaponEffects = new WeaponEffects(scene);
 // Reload audio is authored into the clip as notetracks, so the cues play from
@@ -1593,6 +1647,7 @@ function getDebugState() {
       grounded: player.isGrounded,
       crouched: player.crouched,
       enabled: player.enabled,
+      callsign: playerName.display,
       health: debugRound(playerHealth?.health ?? 0),
       maxHealth: debugRound(playerHealth?.maxHealth ?? 0),
       dead: Boolean(playerHealth?.dead),
@@ -1784,6 +1839,7 @@ document.addEventListener('pointerlockchange', () => {
   // harness out of the totals: `setAutomationActive` and the debug `showMenu`
   // enter the game without ever taking a pointer lock.
   if (locked) {
+    applyCallsign();
     frontend.enter();
     playCounter.record().then(renderPlayCount);
   } else frontend.suspend();
@@ -1830,6 +1886,14 @@ document.addEventListener('keydown', (event) => {
   // Any key but Esc starts or resumes from the shell — Esc is what released
   // the pointer lock to get here, and the browser owns it for a moment after.
   if (frontend.visible) {
+    if (event.target instanceof HTMLInputElement) {
+      if (event.code === 'Enter') {
+        event.preventDefault();
+        applyCallsign(event.target.value);
+        event.target.blur();
+      }
+      return;
+    }
     if (frontend.screen === 'class') {
       if (event.code === 'Escape' || event.code === 'Backspace') frontend.closeClass();
       if (event.code === 'Enter') frontend.confirmClass();

--- a/export/web/player-name.js
+++ b/export/web/player-name.js
@@ -1,0 +1,49 @@
+/**
+ * Title-screen callsign. The match currently registers the human as "YOU";
+ * this is the local half that lets a player type something else and keep it
+ * across visits. Like play-counter.js it holds no DOM, so it tests in node
+ * with a fake storage. Blocked or missing storage falls back to YOU rather
+ * than taking the frontend down.
+ */
+
+const STORAGE_KEY = 'vibeslops:callsign';
+export const DEFAULT_NAME = 'YOU';
+export const MAX_NAME_LENGTH = 16;
+
+export function sanitizeName(value) {
+  const cleaned = String(value ?? '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9 _-]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_NAME_LENGTH)
+    .trim();
+  return cleaned || DEFAULT_NAME;
+}
+
+export class PlayerName {
+  constructor({ storage = null } = {}) {
+    this.storage = storage;
+    this.display = this.read();
+  }
+
+  read() {
+    try {
+      return sanitizeName(this.storage?.getItem(STORAGE_KEY));
+    } catch {
+      return DEFAULT_NAME;
+    }
+  }
+
+  set(value) {
+    this.display = sanitizeName(value);
+    try {
+      this.storage?.setItem(STORAGE_KEY, this.display);
+    } catch {
+      // Keep the in-memory name; they simply type it again next visit.
+    }
+    return this.display;
+  }
+}
+
+export default PlayerName;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/player-name.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/test/free-for-all-match.test.mjs
+++ b/test/free-for-all-match.test.mjs
@@ -33,6 +33,14 @@ test('FFA ends at the score limit or when time expires', () => {
   assert.equal(timed.winnerId, 'b');
 });
 
+test('registering again updates the human callsign on the scoreboard', () => {
+  const match = new FreeForAllMatch();
+  match.register('player', 'YOU', { human: true });
+  match.register('player', 'CLEO', { human: true });
+  assert.equal(match.getState().standings[0].name, 'CLEO');
+  assert.equal(match.getState().standings[0].human, true);
+});
+
 test('suicides count as a death without awarding a kill', () => {
   const match = new FreeForAllMatch();
   match.register('player', 'You');

--- a/test/player-name.test.mjs
+++ b/test/player-name.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { PlayerName, sanitizeName } from '../export/web/player-name.js';
+
+function fakeStorage(initial = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => (data.has(key) ? data.get(key) : null),
+    setItem: (key, value) => data.set(key, String(value)),
+    removeItem: (key) => data.delete(key),
+  };
+}
+
+test('empty and junk names fall back to YOU', () => {
+  assert.equal(sanitizeName(''), 'YOU');
+  assert.equal(sanitizeName('   '), 'YOU');
+  assert.equal(sanitizeName('***'), 'YOU');
+  assert.equal(sanitizeName(null), 'YOU');
+});
+
+test('callsigns are trimmed, uppercased, and capped at 16 characters', () => {
+  assert.equal(sanitizeName('  cleo  '), 'CLEO');
+  assert.equal(sanitizeName('cleo_99'), 'CLEO_99');
+  assert.equal(sanitizeName('hello world'), 'HELLO WORLD');
+  assert.equal(sanitizeName('very-long-callsign-here'), 'VERY-LONG-CALLSI');
+});
+
+test('PlayerName persists to storage and reloads', () => {
+  const storage = fakeStorage();
+  const first = new PlayerName({ storage });
+  assert.equal(first.display, 'YOU');
+  assert.equal(first.set('Corsair'), 'CORSAIR');
+  assert.equal(first.display, 'CORSAIR');
+
+  const returning = new PlayerName({ storage });
+  assert.equal(returning.display, 'CORSAIR');
+});
+
+test('blocked storage still returns a usable name', () => {
+  const storage = {
+    getItem() { throw new Error('blocked'); },
+    setItem() { throw new Error('blocked'); },
+  };
+  const name = new PlayerName({ storage });
+  assert.equal(name.display, 'YOU');
+  assert.equal(name.set('Ada'), 'ADA');
+  assert.equal(name.display, 'ADA');
+});


### PR DESCRIPTION
The free-for-all scoreboard always listed the human as **YOU**. The title screen now offers a callsign field before you click to play.

- Typed names are uppercased, capped at 16 characters, and stored in `localStorage` (`vibeslops:callsign`) so a returning browser keeps the name.
- Empty or junk input still plays as `YOU`.
- Clicking or typing in the field does not start the match; any other key on the title screen still does.
- The name is registered on the FFA standings and kill feed.

Independent of #13 and #14.

### Checks

- `npm run test:unit`: 154 pass, 0 fail (4 new in `test/player-name.test.mjs`)
- `npm run ai:test`: ready, moved, fired, six enemies, no console errors