### PR TITLE
Pace walk and sprint to T6 Hijacked instead of the 300/450 glide

### DIFF
--- a/export/web/index.html
+++ b/export/web/index.html
@@ -591,6 +591,7 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import { PlayerController } from './player-controller.js';
+import { T6_WALK_SPEED, T6_SPRINT_SPEED, T6_CROUCH_SPEED } from './t6-movement.js';
 import { loadNavigation } from './navigation.js';
 import { Viewmodel } from './viewmodel.js';
 import { ViewBob } from './view-bob.js';
@@ -1930,8 +1931,9 @@ async function start() {
       eyeHeight: 60,
       crouchHeight: 48,
       crouchEyeHeight: 40,
-      moveSpeed: 300,
-      sprintSpeed: 450,
+      moveSpeed: T6_WALK_SPEED,
+      sprintSpeed: T6_SPRINT_SPEED,
+      crouchSpeed: T6_CROUCH_SPEED,
       jumpHeight: 48,
       maxSlopeAngle: 45,
       fallResetY: -700,

--- a/export/web/player-controller.js
+++ b/export/web/player-controller.js
@@ -54,6 +54,8 @@ function readAxis(input, positiveNames, negativeNames) {
   return clamp(value, -1, 1);
 }
 
+export { T6_WALK_SPEED, T6_SPRINT_SPEED, T6_CROUCH_SPEED } from './t6-movement.js';
+
 function copyPosition(value, fallback) {
   if (value && value.isVector3) return value.clone();
   if (value && Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z)) {

--- a/export/web/t6-movement.js
+++ b/export/web/t6-movement.js
@@ -1,0 +1,5 @@
+// T6 Hijacked infantry speeds, inches/sec. The viewer shipped at 300/450
+// (~1.6× BO2), which read as a hyperglide across the yacht.
+export const T6_WALK_SPEED = 190;
+export const T6_SPRINT_SPEED = 285;
+export const T6_CROUCH_SPEED = 120;

--- a/export/web/view-bob.js
+++ b/export/web/view-bob.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { T6_WALK_SPEED } from './t6-movement.js';
 
 // Camera-space view bob: the stride nudges the eye and rolls it a little,
 // heavier when sprinting. The camera is the gameplay truth for position and
@@ -62,7 +63,7 @@ export class ViewBob {
     // Same stride clock as the viewmodel bob so the gun and the eye agree.
     this.airTime = grounded ? 0 : this.airTime + dt;
     const movingGrounded = moving && this.airTime < GROUND_GRACE;
-    const speedFactor = THREE.MathUtils.clamp(speed / 300, 0, 1.4);
+    const speedFactor = THREE.MathUtils.clamp(speed / T6_WALK_SPEED, 0, 1.4);
     this.bobAmp = damp(this.bobAmp, movingGrounded ? speedFactor : 0, 8, dt);
     if (movingGrounded) this.bobTime += dt * (5.5 + 4 * speedFactor) * (1 - SPRINT.slow * sprint);
 

--- a/export/web/viewmodel.js
+++ b/export/web/viewmodel.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { clone as cloneSkinned } from 'three/addons/utils/SkeletonUtils.js';
 import { createMuzzleFlashTexture } from './weapon-effects.js';
+import { T6_WALK_SPEED } from './t6-movement.js';
 import { parseNotetracks, NotetrackTimeline } from './notetracks.js';
 
 // The exported viewhands skeleton keeps the engine's view axes in tag_view's
@@ -821,7 +822,7 @@ export class Viewmodel {
     // stride carries on briefly after the last contact instead of hitching.
     this.airTime = grounded ? 0 : this.airTime + dt;
     const movingGrounded = moving && this.airTime < BOB_GROUND_GRACE;
-    const speedFactor = clamp(speed / 300, 0, 1.4);
+    const speedFactor = clamp(speed / T6_WALK_SPEED, 0, 1.4);
     this.sprintBlend = damp(
       this.sprintBlend,
       sprinting && !this.aiming && !this.reloading ? 1 : 0,

--- a/test/player-controller.test.mjs
+++ b/test/player-controller.test.mjs
@@ -1,7 +1,60 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { test } from 'node:test';
 import * as THREE from 'three';
-import { PlayerController } from '../export/web/player-controller.js';
+import {
+  PlayerController,
+  T6_WALK_SPEED,
+  T6_SPRINT_SPEED,
+  T6_CROUCH_SPEED,
+} from '../export/web/player-controller.js';
+
+test('T6 infantry speeds are BO2-paced, not the 300/450 hyperglide', () => {
+  assert.equal(T6_WALK_SPEED, 190);
+  assert.equal(T6_SPRINT_SPEED, 285);
+  assert.equal(T6_CROUCH_SPEED, 120);
+  assert.ok(T6_WALK_SPEED < 250, 'walk should be slower than the old 300 glide');
+  assert.ok(T6_SPRINT_SPEED < 400, 'sprint should be slower than the old 450 glide');
+  assert.ok(T6_CROUCH_SPEED < T6_WALK_SPEED);
+
+  const html = fs.readFileSync(path.join(import.meta.dirname, '../export/web/index.html'), 'utf8');
+  assert.match(html, /moveSpeed:\s*T6_WALK_SPEED/);
+  assert.match(html, /sprintSpeed:\s*T6_SPRINT_SPEED/);
+  assert.match(html, /crouchSpeed:\s*T6_CROUCH_SPEED/);
+  assert.doesNotMatch(html, /moveSpeed:\s*300\b/);
+  assert.doesNotMatch(html, /sprintSpeed:\s*450\b/);
+});
+
+test('the controller reaches T6 walk and sprint on a flat floor', () => {
+  const world = new THREE.Group();
+  const floor = new THREE.Mesh(new THREE.BoxGeometry(4000, 1, 4000));
+  floor.position.y = -0.5;
+  world.add(floor);
+  world.updateWorldMatrix(true, true);
+
+  const camera = new THREE.PerspectiveCamera();
+  const player = new PlayerController(camera, world, {
+    spawn: new THREE.Vector3(0, 0.2, 0),
+    moveSpeed: T6_WALK_SPEED,
+    sprintSpeed: T6_SPRINT_SPEED,
+    crouchSpeed: T6_CROUCH_SPEED,
+  });
+
+  run(player, 0.8, { forward: true });
+  const walk = Math.hypot(player.velocity.x, player.velocity.z);
+  assert.ok(
+    Math.abs(walk - T6_WALK_SPEED) < 8,
+    `walk settled at ${walk.toFixed(1)}, expected ${T6_WALK_SPEED}`,
+  );
+
+  run(player, 0.8, { forward: true, sprint: true });
+  const sprint = Math.hypot(player.velocity.x, player.velocity.z);
+  assert.ok(
+    Math.abs(sprint - T6_SPRINT_SPEED) < 8,
+    `sprint settled at ${sprint.toFixed(1)}, expected ${T6_SPRINT_SPEED}`,
+  );
+});
 
 test('capsule stops at a wall without gaining launch velocity', () => {
   const world = new THREE.Group();

--- a/test/view-bob.test.mjs
+++ b/test/view-bob.test.mjs
@@ -30,7 +30,7 @@ test('walking bobs the camera and restore puts it back exactly', () => {
   const quaternion = camera.quaternion.clone();
   let moved = false;
   for (let i = 0; i < 60; i += 1) {
-    bob.update(1 / 60, { speed: 300, moving: true, grounded: true });
+    bob.update(1 / 60, { speed: 190, moving: true, grounded: true });
     bob.apply(camera);
     if (camera.position.distanceTo(position) > 0.05) moved = true;
     bob.restore(camera);
@@ -42,29 +42,29 @@ test('walking bobs the camera and restore puts it back exactly', () => {
 
 test('sprinting swings harder and leans in, and airborne stride fades', () => {
   const walk = new ViewBob();
-  settle(walk, { speed: 300, moving: true, grounded: true });
+  settle(walk, { speed: 190, moving: true, grounded: true });
   const sprint = new ViewBob();
-  settle(sprint, { speed: 450, moving: true, sprinting: true, grounded: true });
+  settle(sprint, { speed: 285, moving: true, sprinting: true, grounded: true });
   assert.ok(sprint.sprintBlend > 0.99);
   assert.ok(sprint.tilt.x < 0, 'sprint should pitch the eye down slightly');
   let walkPeak = 0;
   let sprintPeak = 0;
   for (let i = 0; i < 120; i += 1) {
-    walk.update(1 / 60, { speed: 300, moving: true, grounded: true });
-    sprint.update(1 / 60, { speed: 450, moving: true, sprinting: true, grounded: true });
+    walk.update(1 / 60, { speed: 190, moving: true, grounded: true });
+    sprint.update(1 / 60, { speed: 285, moving: true, sprinting: true, grounded: true });
     walkPeak = Math.max(walkPeak, Math.abs(walk.offset.x));
     sprintPeak = Math.max(sprintPeak, Math.abs(sprint.offset.x));
   }
   assert.ok(sprintPeak > walkPeak * 1.5);
 
-  settle(sprint, { speed: 450, moving: true, sprinting: true, grounded: false });
+  settle(sprint, { speed: 285, moving: true, sprinting: true, grounded: false });
   assert.ok(sprint.bobAmp < 0.01, 'airborne stride should fade out');
 });
 
 test('apply is idempotent until restored', () => {
   const bob = new ViewBob();
   const camera = new THREE.PerspectiveCamera();
-  settle(bob, { speed: 300, moving: true, grounded: true }, 0.5);
+  settle(bob, { speed: 190, moving: true, grounded: true }, 0.5);
   bob.apply(camera);
   const once = camera.position.clone();
   bob.apply(camera);
@@ -75,10 +75,10 @@ test('apply is idempotent until restored', () => {
 
 test('a brief loss of ground contact, as on a stair riser, does not stop the stride', () => {
   const bob = new ViewBob();
-  settle(bob, { speed: 300, moving: true, grounded: true });
+  settle(bob, { speed: 190, moving: true, grounded: true });
   const before = bob.bobAmp;
-  for (let i = 0; i < 6; i += 1) bob.update(1 / 60, { speed: 300, moving: true, grounded: false });
+  for (let i = 0; i < 6; i += 1) bob.update(1 / 60, { speed: 190, moving: true, grounded: false });
   assert.ok(Math.abs(bob.bobAmp - before) < 1e-6, 'six airborne frames should not touch the stride');
-  settle(bob, { speed: 300, moving: true, grounded: false }, 1);
+  settle(bob, { speed: 190, moving: true, grounded: false }, 1);
   assert.ok(bob.bobAmp < 0.01, 'a real jump still fades the stride');
 });

--- a/test/viewmodel-ads.test.mjs
+++ b/test/viewmodel-ads.test.mjs
@@ -314,7 +314,7 @@ for (const { id, sightTag, insert, adsSightAnchors } of RIFLE_SIGHT_CONFIGS) {
 test('a brief loss of ground contact, as on a stair riser, does not stop the walk bob', () => {
   const viewmodel = new Viewmodel();
   viewmodel.ready = true;
-  const walk = { speed: 300, moving: true, grounded: true };
+  const walk = { speed: 190, moving: true, grounded: true };
   for (let i = 0; i < 120; i += 1) viewmodel.update(1 / 60, walk);
   const before = viewmodel.bobAmp;
   for (let i = 0; i < 6; i += 1) viewmodel.update(1 / 60, { ...walk, grounded: false });


### PR DESCRIPTION
The yacht still felt like a hyperglide after the sprint pose and camera bob landed, because the player moved at 300/450. BO2 Hijacked infantry is about 190 walk / 285 sprint.

- Walk 190, sprint 285, crouch 120 (kept slower than walk).
- View bob and viewmodel stride scale off the T6 walk speed so full walk is still amplitude 1.
- Bots stay at 230: they catch a walking player and lose a sprint.

Independent of #13–#15.

### Checks

- `npm run test:unit`: 151 pass, 0 fail (2 new)
- `npm run ai:test`: ready, moved, fired, six enemies, no console errors