### PR TITLE
Add mobile controls, reliable startup, and adaptive graphics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@
 !/.tools/pack_web_textures.mjs
 !/.tools/ai-game.mjs
 !/.tools/mobile-game.mjs
+!/.tools/graphics-game.mjs
 !/export/
 !/export/web/
 !/export/web/**

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@
 !/.tools/measure_sights.mjs
 !/.tools/pack_web_textures.mjs
 !/.tools/ai-game.mjs
+!/.tools/mobile-game.mjs
 !/export/
 !/export/web/
 !/export/web/**

--- a/.tools/ai-game.mjs
+++ b/.tools/ai-game.mjs
@@ -3,12 +3,14 @@ import http from 'node:http';
 import path from 'node:path';
 import process from 'node:process';
 import { chromium } from 'playwright-core';
+import { runMobileTest } from './mobile-game.mjs';
 
 const root = process.cwd();
 const webRoot = path.resolve(root, 'export', 'web');
-const artifactRoot = path.resolve(root, process.env.AI_GAME_ARTIFACT_DIR ?? 'artifacts/ai-game');
-const viewport = { width: 1280, height: 720 };
+const artifactRoot = path.resolve(root, process.env.AI_GAME_ARTIFACT_DIR ??
+  (process.argv[2] === 'mobile-test' ? 'artifacts/ai-mobile' : 'artifacts/ai-game'));
 const command = process.argv[2] ?? 'help';
+const viewport = command === 'mobile-test' ? { width: 844, height: 390 } : { width: 1280, height: 720 };
 const commandArgument = process.argv[3];
 const commandOption = process.argv[4];
 
@@ -27,6 +29,7 @@ const mimeTypes = new Map([
   ['.glb', 'model/gltf-binary'],
   ['.gltf', 'model/gltf+json'],
   ['.html', 'text/html; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
   ['.js', 'text/javascript; charset=utf-8'],
   ['.json', 'application/json; charset=utf-8'],
   ['.png', 'image/png'],
@@ -43,6 +46,7 @@ Usage:
   npm run ai:game -- test
   npm run ai:game -- enemy-test
   npm run ai:game -- life-test
+  npm run ai:game -- mobile-test
   npm run ai:game -- record [seconds] [weapon]
 
 Environment:
@@ -127,7 +131,7 @@ async function run() {
     process.stdout.write(usage());
     return;
   }
-  if (!['state', 'screenshot', 'test', 'enemy-test', 'life-test', 'record'].includes(command)) {
+  if (!['state', 'screenshot', 'test', 'enemy-test', 'life-test', 'mobile-test', 'record'].includes(command)) {
     throw new Error(`Unknown command: ${command}\n\n${usage()}`);
   }
 
@@ -167,10 +171,9 @@ async function run() {
     });
     context = await browser.newContext({
       viewport,
+      ...(command === 'mobile-test' ? { isMobile: true, hasTouch: true, deviceScaleFactor: 1 } : {}),
       ...(command === 'record' ? { recordVideo: { dir: videoDirectory, size: viewport } } : {}),
     });
-    await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
-    traceStarted = true;
     page = await context.newPage();
     video = page.video();
 
@@ -205,6 +208,11 @@ async function run() {
     // or `screenshot <weapon>` finds only one entry in availableWeapons.
     await page.evaluate(() => globalThis.hijacked.debug.loadAllWeapons());
 
+    // Record the encounter after asset loading; embedding every large binary
+    // transfer adds hundreds of MB and obscures the input/rendering evidence.
+    await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+    traceStarted = true;
+
     await page.evaluate(() => {
       globalThis.hijacked.debug.setActive(true);
       globalThis.hijacked.debug.resume();
@@ -215,7 +223,9 @@ async function run() {
     await writeJson('before-state.json', before);
     await page.screenshot({ path: path.join(artifactRoot, 'before.png') });
 
-    if (command === 'screenshot' && commandArgument) {
+    if (command === 'mobile-test') {
+      inputProbe = await runMobileTest(page, artifactRoot);
+    } else if (command === 'screenshot' && commandArgument) {
       const options = await page.evaluate(() => globalThis.hijacked.debug.getState().weapon);
       if (options.availableWeapons.includes(commandArgument)) {
         const selected = await page.evaluate(
@@ -240,7 +250,12 @@ async function run() {
     } else if (command === 'test') {
       await page.evaluate(() => globalThis.hijacked.debug.resume());
       await page.keyboard.down('w');
-      await page.waitForTimeout(900);
+      // Wall time can contain only a handful of frames under SwiftShader.
+      // Keep real keyboard input held until the physics has actually moved.
+      await page.waitForFunction((origin) => {
+        const feet = globalThis.hijacked.debug.getState().player.feet;
+        return Math.hypot(...feet.map((value, i) => value - origin[i])) > 20;
+      }, before.player.feet, { timeout: 20000 });
       await page.keyboard.up('w');
       await page.evaluate(() => {
         globalThis.__aiMouseProbe = [];
@@ -330,7 +345,10 @@ async function run() {
     await writeJson('state.json', state);
     await page.screenshot({ path: path.join(artifactRoot, 'screenshot.png') });
 
-    const checks = command === 'test' ? {
+    const checks = command === 'mobile-test' ? {
+      ...inputProbe.checks,
+      noBrowserErrors: errors.length === 0,
+    } : command === 'test' ? {
       ready: state.ready === true,
       playerMoved: distance(before.player.feet, state.player.feet) > 10,
       weaponFired: state.weapon.fireCount > before.weapon.fireCount,
@@ -376,6 +394,11 @@ async function run() {
   } catch (error) {
     failure = error;
     errors.push(`[harness] ${error.stack ?? error.message}`);
+    if (page && !page.isClosed()) {
+      const failedState = await page.evaluate(() => globalThis.hijacked?.debug?.getState()).catch(() => null);
+      if (failedState) await writeJson('failure-state.json', failedState);
+      await page.screenshot({ path: path.join(artifactRoot, 'failure.png'), timeout: 10000 }).catch(() => {});
+    }
     result = { command, passed: false, errors, artifacts: artifactRoot };
     await writeJson('report.json', result);
   } finally {

--- a/.tools/ai-game.mjs
+++ b/.tools/ai-game.mjs
@@ -4,13 +4,15 @@ import path from 'node:path';
 import process from 'node:process';
 import { chromium } from 'playwright-core';
 import { runMobileStartup, runMobileTest } from './mobile-game.mjs';
+import { runGraphicsTest } from './graphics-game.mjs';
 
 const root = process.cwd();
 const webRoot = path.resolve(root, 'export', 'web');
 const artifactRoot = path.resolve(root, process.env.AI_GAME_ARTIFACT_DIR ??
-  (process.argv[2] === 'mobile-test' ? 'artifacts/ai-mobile' : 'artifacts/ai-game'));
+  (process.argv[2] === 'mobile-test' ? 'artifacts/ai-mobile' : process.argv[2] === 'graphics-test' ? 'artifacts/ai-graphics' : 'artifacts/ai-game'));
 const command = process.argv[2] ?? 'help';
-const viewport = command === 'mobile-test' ? { width: 844, height: 390 } : { width: 1280, height: 720 };
+const touchContext = ['mobile-test', 'graphics-test'].includes(command) || process.env.AI_GAME_MOBILE === '1';
+const viewport = touchContext ? { width: 844, height: 390 } : { width: 1280, height: 720 };
 const commandArgument = process.argv[3];
 const commandOption = process.argv[4];
 
@@ -47,10 +49,12 @@ Usage:
   npm run ai:game -- enemy-test
   npm run ai:game -- life-test
   npm run ai:game -- mobile-test
+  npm run ai:game -- graphics-test [fallback]
   npm run ai:game -- record [seconds] [weapon]
 
 Environment:
   AI_GAME_HEADED=1             Show the controlled browser window
+  AI_GAME_MOBILE=1             Use a high-density touch viewport (also for record)
   AI_GAME_ARTIFACT_DIR=<path>  Override artifacts/ai-game
   BROWSER_PATH=<path>          Override Chrome or Edge executable
   BROWSER_TEST_URL=<url>       Use an already-running game server
@@ -131,7 +135,7 @@ async function run() {
     process.stdout.write(usage());
     return;
   }
-  if (!['state', 'screenshot', 'test', 'enemy-test', 'life-test', 'mobile-test', 'record'].includes(command)) {
+  if (!['state', 'screenshot', 'test', 'enemy-test', 'life-test', 'mobile-test', 'graphics-test', 'record'].includes(command)) {
     throw new Error(`Unknown command: ${command}\n\n${usage()}`);
   }
 
@@ -173,11 +177,23 @@ async function run() {
     });
     context = await browser.newContext({
       viewport,
-      ...(command === 'mobile-test' ? { isMobile: true, hasTouch: true, deviceScaleFactor: 1 } : {}),
+      ...(touchContext ? { isMobile: true, hasTouch: true, deviceScaleFactor: command === 'mobile-test' ? 1 : 2 } : {}),
       ...(command === 'record' ? { recordVideo: { dir: videoDirectory, size: viewport } } : {}),
     });
     page = await context.newPage();
     video = page.video();
+    if (touchContext) {
+      await page.route('**/api/plays', route => route.fulfill({ contentType: 'application/json', body: '{"players":1,"plays":1}' }));
+    }
+    if (command === 'graphics-test' && commandArgument === 'fallback') {
+      await page.addInitScript(() => {
+        const original = WebGL2RenderingContext.prototype.getInternalformatParameter;
+        WebGL2RenderingContext.prototype.getInternalformatParameter = function(target, format, pname) {
+          if (format === this.RGBA16F && pname === this.SAMPLES) return new Int32Array();
+          return original.call(this, target, format, pname);
+        };
+      });
+    }
 
     page.on('console', (message) => {
       const entry = `[console:${message.type()}] ${message.text()}`;
@@ -231,6 +247,8 @@ async function run() {
 
     if (command === 'mobile-test') {
       inputProbe = await runMobileTest(page, artifactRoot);
+    } else if (command === 'graphics-test') {
+      inputProbe = await runGraphicsTest(page, artifactRoot, commandArgument === 'fallback');
     } else if (command === 'screenshot' && commandArgument) {
       const options = await page.evaluate(() => globalThis.hijacked.debug.getState().weapon);
       if (options.availableWeapons.includes(commandArgument)) {
@@ -351,7 +369,7 @@ async function run() {
     await writeJson('state.json', state);
     await page.screenshot({ path: path.join(artifactRoot, 'screenshot.png') });
 
-    const checks = command === 'mobile-test' ? {
+    const checks = ['mobile-test', 'graphics-test'].includes(command) ? {
       ...startupChecks,
       ...inputProbe.checks,
       noBrowserErrors: errors.length === 0,

--- a/.tools/ai-game.mjs
+++ b/.tools/ai-game.mjs
@@ -3,7 +3,7 @@ import http from 'node:http';
 import path from 'node:path';
 import process from 'node:process';
 import { chromium } from 'playwright-core';
-import { runMobileTest } from './mobile-game.mjs';
+import { runMobileStartup, runMobileTest } from './mobile-game.mjs';
 
 const root = process.cwd();
 const webRoot = path.resolve(root, 'export', 'web');
@@ -140,7 +140,8 @@ async function run() {
   await fs.promises.mkdir(artifactRoot, { recursive: true });
 
   const ownedServer = process.env.BROWSER_TEST_URL ? null : await staticServer();
-  const gameUrl = autostartUrl(process.env.BROWSER_TEST_URL ?? ownedServer.url);
+  const baseUrl = process.env.BROWSER_TEST_URL ?? ownedServer.url;
+  const gameUrl = command === 'mobile-test' ? baseUrl : autostartUrl(baseUrl);
   const consoleMessages = [];
   const errors = [];
   const recordSeconds = Math.max(1, Math.min(60, Number(commandArgument) || 5));
@@ -155,6 +156,7 @@ async function run() {
   let result;
   let failure;
   let inputProbe = null;
+  let startupChecks = {};
 
   try {
     browser = await chromium.launch({
@@ -195,8 +197,12 @@ async function run() {
       if (!entry.includes('net::ERR_ABORTED')) errors.push(entry);
     });
 
-    const response = await page.goto(gameUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 });
-    if (!response?.ok()) throw new Error(`Game returned HTTP ${response?.status() ?? 'unknown'}`);
+    if (command === 'mobile-test') {
+      startupChecks = await runMobileStartup(page, artifactRoot, gameUrl);
+    } else {
+      const response = await page.goto(gameUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+      if (!response?.ok()) throw new Error(`Game returned HTTP ${response?.status() ?? 'unknown'}`);
+    }
     await page.waitForFunction(
       () => globalThis.hijacked?.debug?.getState().ready === true,
       null,
@@ -346,6 +352,7 @@ async function run() {
     await page.screenshot({ path: path.join(artifactRoot, 'screenshot.png') });
 
     const checks = command === 'mobile-test' ? {
+      ...startupChecks,
       ...inputProbe.checks,
       noBrowserErrors: errors.length === 0,
     } : command === 'test' ? {

--- a/.tools/graphics-game.mjs
+++ b/.tools/graphics-game.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function runGraphicsTest(page, artifactRoot, fallback = false) {
+  const states = {}, checks = {};
+  const check = (name, passed) => { checks[name] = Boolean(passed); assert.ok(passed, name); };
+  const shot = async name => {
+    process.stdout.write(`Graphics: ${name}\n`);
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    states[name] = await page.evaluate(() => globalThis.hijacked.debug.getState());
+    await page.screenshot({ path: path.join(artifactRoot, `graphics-${name}.png`) });
+    await fs.writeFile(path.join(artifactRoot, 'graphics-states.json'), JSON.stringify(states, null, 2));
+    return states[name];
+  };
+  const auto = await shot('auto');
+  check('autoSharperThanCssResolution', auto.performance.pixelRatio === 1.5);
+  check('antialiasesScene', ['msaa', 'fxaa'].includes(auto.performance.graphics.antialiasing));
+  if (fallback) check('fxaaFallback', auto.performance.graphics.antialiasing === 'fxaa');
+  check('filtersWorldAndWeapon', auto.performance.graphics.filteredTextures > 20 && auto.performance.graphics.anisotropy > 1);
+  await page.evaluate(() => globalThis.hijacked.debug.setGraphicsPreset('performance'));
+  await shot('performance');
+  await page.evaluate(() => globalThis.hijacked.debug.setGraphicsPreset('auto'));
+  await page.evaluate(() => globalThis.hijacked.debug.showMenu(true));
+  await shot('menu');
+  for (const preset of ['performance', 'quality', 'auto', 'performance', 'quality']) {
+    await page.locator('#touch-graphics').selectOption(preset);
+    const state = await shot(`${preset}-${Object.keys(states).length}`);
+    check(`${preset}PresetApplies`, state.performance.graphics.preset === preset && state.menu.visible);
+    check(`${preset}BuffersMatch`, JSON.stringify(state.performance.drawingBuffer) === JSON.stringify(state.performance.graphics.sceneBuffer));
+    check(`${preset}Persists`, await page.evaluate(p => localStorage.getItem('hijacked.graphics') === p, preset));
+    if (preset === 'performance') check('performanceDisablesAa', state.performance.graphics.antialiasing === 'off' && state.performance.pixelRatio === 1);
+    if (preset === 'quality') check('qualitySharper', state.performance.pixelRatio === 2);
+  }
+  await page.evaluate(() => globalThis.hijacked.debug.showMenu(false));
+  await shot('quality');
+  await page.setViewportSize({ width: 390, height: 844 });
+  const portrait = await shot('portrait');
+  check('portraitBufferResizes', portrait.performance.drawingBuffer[0] === 780 && portrait.performance.drawingBuffer[1] === 1688);
+  await page.setViewportSize({ width: 2048, height: 1536 });
+  const tablet = await shot('tablet');
+  check('tabletPixelBudget', tablet.performance.drawingBuffer[0] * tablet.performance.drawingBuffer[1] <= 1800000);
+  await page.setViewportSize({ width: 844, height: 390 });
+  await shot('landscape');
+  await page.evaluate(() => {
+    const api = globalThis.hijacked.debug;
+    api.setGraphicsPreset('performance'); api.respawnPlayer(); api.resume();
+  });
+  await shot('input-setup');
+  await page.waitForFunction(() => globalThis.hijacked.debug.getState().input.touch.enabled);
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ id: 1, x: 110, y: 310 }] });
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ id: 1, x: 110, y: 285 }] });
+  const held = await shot('held-movement');
+  await page.evaluate(() => globalThis.hijacked.debug.setGraphicsPreset('quality'));
+  const changed = await shot('quality-while-moving');
+  check('resolutionPreservesTouch', changed.input.touch.pointers === 1 && changed.input.touch.forward === held.input.touch.forward && held.input.touch.forward > 0);
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await shot('released');
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => globalThis.hijacked?.debug?.getState().ready, null, { timeout: 180000 });
+  const reloaded = await shot('reloaded');
+  check('presetSurvivesReload', reloaded.performance.graphics.preset === 'quality' && await page.locator('#touch-graphics').inputValue() === 'quality');
+  return { checks, states: Object.keys(states) };
+}

--- a/.tools/mobile-game.mjs
+++ b/.tools/mobile-game.mjs
@@ -2,6 +2,67 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+// Exercise a cold visit, including a tap before the game modules finish loading.
+// The full touch suite must not silently bypass this path with ?autostart=1.
+export async function runMobileStartup(page, artifactRoot, url) {
+  const checks = {};
+  const observations = {};
+  let mapRequests = 0;
+  const countMap = request => { if (new URL(request.url()).pathname.endsWith('/hijacked_optimized.glb')) mapRequests++; };
+  page.on('request', countMap);
+  let releaseModule;
+  let pendingModule;
+  const moduleGate = new Promise(resolve => { releaseModule = resolve; });
+  const delayModule = route => {
+    pendingModule = moduleGate.then(() => route.continue());
+    return pendingModule;
+  };
+  await page.route('**/touch-controls.js', delayModule);
+  const check = (name, passed) => { checks[name] = Boolean(passed); assert.ok(passed, name); };
+  const shot = async name => {
+    observations[name] = await page.evaluate(() => ({
+      screen: document.getElementById('blocker').dataset.screen,
+      text: document.getElementById('blocker').innerText,
+      state: globalThis.hijacked?.debug?.getState() ?? null,
+    }));
+    observations[name].mapRequests = mapRequests;
+    await page.screenshot({ path: path.join(artifactRoot, `startup-${name}.png`) });
+    await fs.writeFile(path.join(artifactRoot, 'startup-states.json'), JSON.stringify(observations, null, 2));
+    return observations[name];
+  };
+  try {
+    const response = await page.goto(url, { waitUntil: 'commit', timeout: 30000 });
+    assert.ok(response?.ok(), `Game returned HTTP ${response?.status()}`);
+    await page.waitForFunction(() => globalThis.hijackedStartup instanceof Promise);
+    const prompt = page.locator('#fe-load-game');
+    await prompt.waitFor({ state: 'visible' });
+    const welcome = await shot('welcome');
+    check('startupPromptVisible', welcome.screen === 'welcome' && /tap.*load/i.test(welcome.text));
+    check('startupWaitsForTouch', mapRequests === 0 && welcome.state === null && !welcome.text.includes('0%'));
+    const bounds = await prompt.boundingBox();
+    assert.ok(bounds && bounds.height >= 44, 'startup needs a finger-sized target');
+    // Locator actions wait for the pending document load. This gesture must
+    // happen while that load is deliberately held, as on a slow connection.
+    await page.touchscreen.tap(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+    const loading = await shot('early-touch');
+    check('earlyTouchStartsLoading', loading.screen === 'loading' && loading.state === null);
+    // Touchstart, pointerdown and compatibility click must share one boot.
+    await page.touchscreen.tap(400, 180);
+    await shot('repeated-touch');
+    releaseModule();
+    await page.waitForFunction(() => globalThis.hijacked?.debug?.getState().ready, null, { timeout: 180000 });
+    const loaded = await shot('ready');
+    check('earlyTouchReachesTitle', loaded.state?.ready && loaded.screen === 'title');
+    check('startupDownloadsMapOnce', mapRequests === 1);
+    return checks;
+  } finally {
+    releaseModule();
+    await pendingModule;
+    await page.unroute('**/touch-controls.js', delayModule);
+    page.off('request', countMap);
+  }
+}
+
 // Chromium's input protocol sends trusted, simultaneous touch contacts through
 // the browser's hit testing, pointer capture and gesture arbitration.
 export async function runMobileTest(page, artifactRoot) {

--- a/.tools/mobile-game.mjs
+++ b/.tools/mobile-game.mjs
@@ -1,0 +1,217 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+// Chromium's input protocol sends trusted, simultaneous touch contacts through
+// the browser's hit testing, pointer capture and gesture arbitration.
+export async function runMobileTest(page, artifactRoot) {
+  const checks = {};
+  const states = {};
+  const state = () => page.evaluate(() => globalThis.hijacked.debug.getState());
+  const shot = async (name) => {
+    process.stdout.write(`Mobile: ${name}\n`);
+    await page.evaluate(() => new Promise(requestAnimationFrame));
+    states[name] = await state();
+    await page.screenshot({ path: path.join(artifactRoot, `mobile-${name}.png`) });
+    await fs.writeFile(path.join(artifactRoot, 'mobile-states.json'), JSON.stringify(states, null, 2));
+    return states[name];
+  };
+  const check = (name, passed) => { checks[name] = Boolean(passed); assert.ok(passed, name); };
+  const center = async (selector) => {
+    const box = await page.locator(selector).boundingBox();
+    assert.ok(box, `${selector} must be visible`);
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  };
+  const tap = async (selector, name, settled = null) => {
+    const bounds = await page.locator(selector).boundingBox();
+    const size = page.viewportSize();
+    if (bounds && (bounds.y < 0 || bounds.y + bounds.height > size.height)) {
+      await page.locator(selector).scrollIntoViewIfNeeded();
+      await shot(`${name}-scroll`);
+    }
+    const p = await center(selector);
+    await page.touchscreen.tap(p.x, p.y);
+    if (settled) await wait(settled);
+    return shot(name);
+  };
+  const cdp = await page.context().newCDPSession(page);
+  const points = new Map();
+  const contact = async (type, id, position) => {
+    if (type === 'touchEnd') {
+      // Chromium ends the supplied contact IDs, rather than treating this
+      // array as the remaining fingers (an empty array releases everything).
+      await cdp.send('Input.dispatchTouchEvent', { type, touchPoints: [points.get(id)] });
+      points.delete(id);
+    } else {
+      points.set(id, { id, ...position, radiusX: 8, radiusY: 8, force: 1 });
+      await cdp.send('Input.dispatchTouchEvent', { type, touchPoints: [...points.values()] });
+    }
+  };
+  const release = async () => {
+    points.clear();
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  };
+  const wait = (predicate) => page.waitForFunction(predicate, null, { timeout: 45000 });
+  const buttonsFit = async () => page.locator('#touch-controls button').evaluateAll(buttons =>
+    buttons.every(button => {
+      const r = button.getBoundingClientRect();
+      return r.width >= 44 && r.height >= 44 && r.left >= 0 && r.top >= 0 &&
+        r.right <= innerWidth && r.bottom <= innerHeight;
+    }));
+
+  await page.evaluate(() => globalThis.hijacked.debug.setActive(false));
+  await shot('menu-landscape');
+  const started = await tap('[data-action="resume"]', 'landscape');
+  await wait(() => globalThis.hijacked.debug.getState().input.touch.enabled);
+  check('touchStartsWithoutPointerLock', started.active && started.input.touch.mode &&
+    await page.evaluate(() => document.pointerLockElement === null));
+  check('landscapeTargetsFit', await buttonsFit());
+
+  const origin = await center('.touch-stick');
+  const beforeMove = await state();
+  await contact('touchStart', 1, origin);
+  await contact('touchMove', 1, { x: origin.x, y: origin.y - 28 });
+  await wait(() => globalThis.hijacked.debug.getState().input.touch.forward > 0.3);
+  const walking = await shot('walk');
+  check('analogWalk', walking.input.touch.forward > 0.3 && walking.input.touch.forward < 0.8 && !walking.input.touch.sprint);
+  check('touchMovesPlayer', Math.hypot(...walking.player.feet.map((v, i) => v - beforeMove.player.feet[i])) > 1);
+  await contact('touchMove', 1, { x: origin.x, y: origin.y - 55 });
+  const sprinting = await shot('sprint');
+  check('pushToSprint', sprinting.input.touch.sprint);
+
+  const look = { x: 460, y: 160 };
+  await contact('touchStart', 2, look);
+  await contact('touchMove', 2, { x: look.x + 50, y: look.y + 15 });
+  const looking = await shot('move-and-look');
+  check('simultaneousMoveAndLook', looking.input.touch.pointers === 2 &&
+    Math.hypot(...looking.player.forward.map((v, i) => v - sprinting.player.forward[i])) > 0.1);
+  await contact('touchEnd', 2);
+  await shot('look-release');
+  const fire = await center('[data-touch="fire"]');
+  await contact('touchStart', 3, fire);
+  await contact('touchMove', 3, { x: fire.x - 28, y: fire.y - 10 });
+  await wait(() => globalThis.hijacked.debug.getState().weapon.fireCount > 0);
+  const firing = await shot('move-and-fire');
+  check('fireWhileMoving', firing.weapon.triggerHeld && firing.weapon.fireCount > 0 && firing.input.touch.forward > 0.9);
+  check('firingCancelsSprint', !firing.input.touch.sprint);
+  check('dragFireAims', Math.hypot(...firing.player.forward.map((v, i) => v - looking.player.forward[i])) > 0.05);
+  await release();
+  const released = await shot('released');
+  check('releaseClearsMovementAndFire', released.input.touch.pointers === 0 &&
+    released.input.touch.forward === 0 && !released.weapon.triggerHeld);
+
+  // Screenshot encoding can keep the fire contact down long enough to empty
+  // a magazine on a slow renderer. Start the independent action probes with
+  // a fresh life, clear of that automatic reload and the movement-test wall.
+  await page.evaluate((before) => {
+    const debug = globalThis.hijacked.debug;
+    debug.respawnPlayer();
+    debug.teleportPlayer(before.player.feet);
+    debug.lookAt(before.player.eye.map((v, i) => v + before.player.forward[i] * 1000));
+  }, beforeMove);
+  await shot('actions-setup');
+
+  const aiming = await tap('[data-touch="aim"]', 'aim',
+    () => globalThis.hijacked.debug.getState().weapon.aiming);
+  check('tapAimTogglesOn', aiming.input.touch.aim && aiming.weapon.aiming);
+  const unAiming = await tap('[data-touch="aim"]', 'hip',
+    () => !globalThis.hijacked.debug.getState().weapon.aiming);
+  check('tapAimTogglesOff', !unAiming.input.touch.aim && !unAiming.weapon.aiming);
+  await tap('[data-touch="crouch"]', 'crouch');
+  await wait(() => globalThis.hijacked.debug.getState().player.crouched);
+  check('tapCrouch', (await state()).player.crouched);
+  await tap('[data-touch="crouch"]', 'stand');
+  await wait(() => !globalThis.hijacked.debug.getState().player.crouched);
+  // Start from the same unobstructed deck for the jump and interruption probes.
+  await page.evaluate((feet) => globalThis.hijacked.debug.teleportPlayer(feet), beforeMove.player.feet);
+  await shot('jump-setup');
+  await wait(() => globalThis.hijacked.debug.getState().player.grounded);
+  const jump = await center('[data-touch="jump"]');
+  await page.touchscreen.tap(jump.x, jump.y);
+  await wait(() => globalThis.hijacked.debug.getState().player.velocity[1] > 0);
+  const jumping = await shot('jump');
+  check('quickTapJumps', jumping.player.feet[1] > beforeMove.player.feet[1] + 1);
+  await page.evaluate(() => globalThis.hijacked.debug.setWeaponAmmo(12, 240));
+  await shot('reload-setup');
+  const reloading = await tap('[data-touch="reload"]', 'reload',
+    () => globalThis.hijacked.debug.getState().weapon.reloading);
+  check('tapReload', reloading.weapon.reloading);
+  await wait(() => !globalThis.hijacked.debug.getState().weapon.reloading);
+  const reloaded = await shot('reloaded');
+  check('reloadCompletes', reloaded.weapon.magazine === reloaded.weapon.magazineSize);
+
+  await contact('touchStart', 1, await center('.touch-stick'));
+  await contact('touchStart', 2, await center('[data-touch="fire"]'));
+  await shot('cancel-setup');
+  points.clear();
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] });
+  const cancelled = await shot('cancelled');
+  check('cancelClearsContacts', cancelled.input.touch.pointers === 0 && !cancelled.weapon.triggerHeld);
+  await tap('#touch-scores', 'scores');
+  check('scoreboardReachable', await page.locator('#scoreboard').isVisible());
+  await tap('#touch-score-close', 'scores-closed');
+  check('scoreboardDismissible', !await page.locator('#scoreboard').isVisible());
+  await contact('touchStart', 1, await center('.touch-stick'));
+  await contact('touchStart', 2, await center('[data-touch="fire"]'));
+  await shot('pause-setup');
+  await contact('touchStart', 3, await center('#touch-pause'));
+  await shot('pause-held-inputs');
+  await release();
+  await shot('pause');
+  check('touchPause', !(await state()).active && !(await state()).input.touch.visible);
+  // A slider gesture must not bubble into the shell's tap-to-resume action.
+  await tap('#touch-sensitivity', 'sensitivity');
+  check('settingsDoNotResume', !(await state()).active);
+  await tap('[data-action="class"]:visible', 'classes-landscape');
+  await tap('[data-weapon-id="an94"]', 'class-selected');
+  await tap('[data-action="class-confirm"]', 'class-confirmed');
+  check('touchClassSelection', (await state()).weapon.id === 'an94');
+  await tap('[data-action="resume"]', 'resumed');
+  await contact('touchStart', 1, await center('[data-touch="fire"]'));
+  await shot('rotation-setup');
+  await page.setViewportSize({ width: 390, height: 844 });
+  await release();
+  const portrait = await shot('portrait');
+  check('rotationClearsFire', portrait.input.touch.pointers === 0 && !portrait.weapon.triggerHeld);
+  check('portraitTargetsFit', await buttonsFit());
+  const portraitPaused = await tap('#touch-pause', 'menu-portrait');
+  check('singleFingerPauseAfterRotation', !portraitPaused.active && portraitPaused.menu.visible);
+  await tap('[data-action="class"]:visible', 'classes-portrait');
+  await page.locator('[data-action="class-back"]').scrollIntoViewIfNeeded();
+  await shot('classes-portrait-scrolled');
+  await tap('[data-action="class-back"]', 'class-back-portrait');
+  await page.locator('[data-action="resume"]').scrollIntoViewIfNeeded();
+  await tap('[data-action="resume"]', 'portrait-resumed');
+  await page.evaluate(() => globalThis.hijacked.debug.respawnPlayer());
+  await shot('death-setup');
+  await contact('touchStart', 1, await center('[data-touch="fire"]'));
+  await page.evaluate(() => globalThis.hijacked.debug.damagePlayer(1000));
+  const dead = await shot('death');
+  check('deathClearsTouch', dead.player.dead && !dead.input.touch.enabled && dead.input.touch.pointers === 0);
+  await release();
+  await wait(() => !globalThis.hijacked.debug.getState().player.dead);
+  const respawned = await shot('respawned');
+  check('respawnHasNoStuckTrigger', respawned.input.touch.enabled && !respawned.weapon.triggerHeld);
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  const blurred = await shot('blur');
+  check('interruptionPauses', !blurred.active && blurred.input.touch.pointers === 0);
+  await tap('[data-action="resume"]', 'after-interruption');
+  await page.evaluate(() => globalThis.hijacked.debug.finishMatch());
+  await shot('match-ended');
+  check('matchRestartReachable', await page.locator('#touch-restart').isVisible());
+  const restarted = await tap('#touch-restart', 'match-restarted');
+  check('touchRestartsMatch', restarted.match.phase === 'playing' && restarted.active && restarted.player.enabled);
+  for (const [name, size] of [
+    ['small-phone', { width: 320, height: 568 }],
+    ['tablet', { width: 1024, height: 768 }],
+  ]) {
+    await page.setViewportSize(size);
+    await shot(name);
+    check(`${name}TargetsFit`, await buttonsFit());
+  }
+  await page.setViewportSize({ width: 844, height: 390 });
+  await shot('landscape-final');
+  await page.evaluate(() => globalThis.hijacked.debug.pause());
+  await shot('final');
+  return { checks, states: Object.keys(states) };
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ behavior or visuals.
    `npm run ai:record -- 10` and inspect `recording.webm` or `trace.zip`.
 6. For enemy perception, navigation, combat, or coordination work, run
    `npm run ai:enemy` to stage a reproducible six-enemy encounter.
+7. For touch input or mobile layout work, run `npm run ai:mobile`. It drives
+   simultaneous browser touch contacts and saves state, screenshots, and a
+   trace to `artifacts/ai-mobile`, including portrait and landscape layouts.
 
 The harness launches its own HTTP server and Chrome/Edge. Set
 `AI_GAME_HEADED=1` only when a visible browser is useful. Generated artifacts
@@ -39,6 +42,8 @@ gameplay implementation details:
 - `damagePlayer(number)`, `respawnPlayer()`, and `respawnEnemies()` create test
   conditions.
 - `teleportEnemy(index, [x, y, z])` and `alertEnemies(radius)` stage encounters.
+- `finishMatch()` stages the results screen; `getState().input.touch` observes
+  touch mode, pointer count, movement axes, and action state.
 
 When adding a gameplay system, expose only compact, serializable observations
 or safe test controls through this API. Do not expose frame-sized geometry,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ behavior or visuals.
 7. For touch input or mobile layout work, run `npm run ai:mobile`. It drives
    simultaneous browser touch contacts and saves state, screenshots, and a
    trace to `artifacts/ai-mobile`, including portrait and landscape layouts.
+8. For graphics presets or output-buffer changes, run `npm run ai:graphics`
+   and `npm run ai:graphics -- fallback`. Inspect their `graphics-*.png`
+   comparisons and `graphics-states.json`; retain separate artifact directories.
 
 The harness launches its own HTTP server and Chrome/Edge. Set
 `AI_GAME_HEADED=1` only when a visible browser is useful. Generated artifacts
@@ -44,6 +47,8 @@ gameplay implementation details:
 - `teleportEnemy(index, [x, y, z])` and `alertEnemies(radius)` stage encounters.
 - `finishMatch()` stages the results screen; `getState().input.touch` observes
   touch mode, pointer count, movement axes, and action state.
+- `setGraphicsPreset('auto' | 'performance' | 'quality')` changes the saved
+  graphics setting; `getState().performance.graphics` observes rendering quality.
 
 When adding a gameplay system, expose only compact, serializable observations
 or safe test controls through this API. Do not expose frame-sized geometry,

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Controls:
 - `P`: find and draw a navmesh path to the point under the crosshair
 - `Esc`: pause and release the mouse
 
-On a phone or tablet, tap to deploy. Drag the left stick to walk and push it
+On a phone or tablet, tap **Tap or click to load**, then tap to deploy once the
+game is ready. Drag the left stick to walk and push it
 fully forward to sprint. Swipe on the right to look; hold **FIRE** and drag it
 to aim while shooting. **AIM** and **CROUCH** toggle, while **JUMP** and
 **RELOAD** act on a tap. Aiming or firing automatically interrupts sprint.
@@ -186,9 +187,10 @@ been tried and was not enough on its own.
 
 Two consequences worth knowing:
 
-- Automation has to opt out with `?autostart=1`, which `browser-smoke.mjs` and
-  `ai-game.mjs` both do. Without it they wait forever for a game that is
-  deliberately not loading.
+- Automation must either send input or opt out with `?autostart=1`. Desktop
+  smoke checks opt out; `ai:mobile` tests the welcome prompt and sends a real
+  touch before the game modules finish loading, then verifies startup completes
+  with exactly one map download. Early visitor input is remembered while scripts load.
 - Only the equipped rifle loads at boot. The other eight are fetched when the
   class screen opens, so scripted runs that select a rifle directly need
   `await hijacked.debug.loadAllWeapons()` first.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Controls:
 - `P`: find and draw a navmesh path to the point under the crosshair
 - `Esc`: pause and release the mouse
 
+On a phone or tablet, tap to deploy. Drag the left stick to walk and push it
+fully forward to sprint. Swipe on the right to look; hold **FIRE** and drag it
+to aim while shooting. **AIM** and **CROUCH** toggle, while **JUMP** and
+**RELOAD** act on a tap. Aiming or firing automatically interrupts sprint.
+The top-right buttons open scores and pause. The pause menu includes class
+selection, saved look sensitivity, and optional full screen. Both orientations
+work; landscape leaves more room around the controls.
+
 ## Frontend
 
 The viewer opens on a menu shell rather than a bare loading message. It has a
@@ -136,10 +144,10 @@ that have. The split is deliberate: `players` is the honest answer to "how many
 people have played", and `plays` is the one that moves.
 
 `export/web/play-counter.js` holds the client half and, like `frontend.js`,
-touches no DOM so it tests in node. A play is recorded when pointer lock is
-granted, not when the page loads, so social-card scrapers and bounced tabs
-never reach it; the automation harness enters through `setAutomationActive`
-without taking a lock, so the smoke tests stay out of the totals too. The first
+touches no DOM so it tests in node. A play is recorded when a desktop player
+takes pointer lock or a touch player deploys. Social-card scrapers and bounced
+tabs never reach it; the automation harness enters through `setAutomationActive`
+without counting a play, and the mobile harness uses a local counter stub. The first
 record per page session latches, so resuming from the pause menu does not count
 again. New-versus-returning is a `vibeslops:player` key in `localStorage` —
 clearing site data counts you again, which is unavoidable without asking
@@ -326,6 +334,7 @@ npm run ai:screenshot
 npm run ai:test
 npm run ai:enemy
 npm run ai:life
+npm run ai:mobile
 npm run ai:record -- 10
 ```
 
@@ -338,6 +347,10 @@ Outputs are written to `artifacts/ai-game/`:
 - `trace.zip`: a Playwright trace with screenshots and DOM snapshots
 - `recording.webm`: video produced by `ai:record`
 - `report.json`: machine-readable checks and pass/fail status
+
+`ai:mobile` writes to `artifacts/ai-mobile/`. It tests simultaneous touch
+contacts, action buttons, interruption recovery, class selection, and match
+restart, with screenshots at phone and tablet sizes in both orientations.
 
 Set `AI_GAME_HEADED=1` to watch the controlled browser. `BROWSER_TEST_URL` can
 point the harness at an existing server, and `BROWSER_PATH` can select a custom

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ The top-right buttons open scores and pause. The pause menu includes class
 selection, saved look sensitivity, and optional full screen. Both orientations
 work; landscape leaves more room around the controls.
 
+Mobile graphics default to **Auto**, which starts at up to 1.5× resolution
+and adjusts gradually to sustained frame times. **Performance** uses up to
+1× resolution and disables edge smoothing; **Quality** uses up to 2× with
+stronger texture filtering. Both Auto and Quality smooth the scene and weapon
+edges using supported HDR multisampling, with FXAA as the fallback. Resolution
+stays within pixel and GPU size limits. Choose a preset from the title or pause
+menu; the selection is saved on the device.
+
 ## Frontend
 
 The viewer opens on a menu shell rather than a bare loading message. It has a
@@ -337,6 +345,8 @@ npm run ai:test
 npm run ai:enemy
 npm run ai:life
 npm run ai:mobile
+npm run ai:graphics
+npm run ai:graphics -- fallback
 npm run ai:record -- 10
 ```
 
@@ -353,6 +363,15 @@ Outputs are written to `artifacts/ai-game/`:
 `ai:mobile` writes to `artifacts/ai-mobile/`. It tests simultaneous touch
 contacts, action buttons, interruption recovery, class selection, and match
 restart, with screenshots at phone and tablet sizes in both orientations.
+
+`ai:graphics` writes to `artifacts/ai-graphics/`. It checks rendering presets,
+high-density phone buffers, portrait/tablet resizing, persistence, and held
+touch input across resolution changes. `fallback` simulates unavailable HDR
+multisampling to verify the FXAA path. Use `AI_GAME_ARTIFACT_DIR` to retain both
+runs separately. These software-rendered checks verify behavior and visuals;
+real-device frame rates and battery use need phone measurements.
+Set `AI_GAME_MOBILE=1` with `npm run ai:record -- 10 m27` to record the mobile
+rendering path at a high-density phone viewport.
 
 Set `AI_GAME_HEADED=1` to watch the controlled browser. `BROWSER_TEST_URL` can
 point the harness at an existing server, and `BROWSER_PATH` can select a custom

--- a/export/web/frontend.js
+++ b/export/web/frontend.js
@@ -27,11 +27,12 @@ const CAPTIONS = {
   'enemy weapon': 'enemy weapon',
 };
 
-export const SCREENS = ['loading', 'title', 'pause', 'class', 'error'];
+export const SCREENS = ['welcome', 'loading', 'title', 'pause', 'class', 'error'];
 
 export class Frontend {
   constructor({
     elements = null, onPlay = null, onResume = null, onSelectWeapon = null, onOpenClass = null,
+    waitingForInput = false,
   } = {}) {
     this.elements = elements;
     this.onPlay = onPlay;
@@ -41,7 +42,7 @@ export class Frontend {
     // has not loaded yet. Only a player who browses classes pays for them.
     this.onOpenClass = onOpenClass;
 
-    this.screen = 'loading';
+    this.screen = waitingForInput ? 'welcome' : 'loading';
     this.playing = false;
     this.loads = new Map();
     this.expected = new Map();
@@ -65,6 +66,14 @@ export class Frontend {
 
   get ready() {
     return this.screen === 'title' || this.screen === 'pause';
+  }
+
+  /** The first visitor gesture starts loading; waiting is not download progress. */
+  startLoading() {
+    if (this.screen !== 'welcome') return false;
+    this.screen = 'loading';
+    this.render();
+    return true;
   }
 
   /**

--- a/export/web/graphics-renderer.js
+++ b/export/web/graphics-renderer.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
+import { chooseSamples } from './graphics-settings.js';
+
+// Smooth the actual scene target; canvas antialiasing would only smooth the
+// fullscreen grading quad. FXAA handles GPUs without multisampled HDR buffers.
+export class GraphicsRenderer {
+  constructor(renderer) {
+    this.renderer = renderer;
+    const gl = renderer.getContext();
+    this.samples = chooseSamples(
+      gl.getInternalformatParameter(gl.RENDERBUFFER, gl.RGBA16F, gl.SAMPLES) ?? [],
+      gl.getInternalformatParameter(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, gl.SAMPLES) ?? [],
+    );
+    this.mode = 'off';
+    this.filteredTextures = 0;
+    this.target = null;
+    this.material = null;
+    this.scene = null;
+  }
+
+  configure(enabled, sceneTarget) {
+    this.mode = enabled ? (this.samples ? 'msaa' : 'fxaa') : 'off';
+    const samples = this.mode === 'msaa' ? this.samples : 0;
+    if (sceneTarget.samples !== samples) {
+      sceneTarget.dispose();
+      sceneTarget.samples = samples;
+    }
+    sceneTarget.resolveDepthBuffer = false;
+    if (this.mode === 'fxaa' && !this.target) {
+      // The grading shader already encodes sRGB. Keep these display-referred
+      // bytes unchanged through FXAA, avoiding a second tone/colour conversion.
+      this.target = new THREE.WebGLRenderTarget(1, 1, { depthBuffer: false });
+      this.material = new THREE.ShaderMaterial({ ...FXAAShader,
+        uniforms: THREE.UniformsUtils.clone(FXAAShader.uniforms), depthTest: false, depthWrite: false });
+      this.scene = new THREE.Scene();
+      this.scene.add(new THREE.Mesh(new THREE.PlaneGeometry(2, 2), this.material));
+    } else if (this.mode !== 'fxaa' && this.target) {
+      this.target.dispose();
+      this.material.dispose();
+      this.scene.children[0].geometry.dispose();
+      this.target = this.material = this.scene = null;
+    }
+    this.setSize(sceneTarget.width, sceneTarget.height);
+  }
+
+  setSize(width, height) {
+    this.target?.setSize(width, height);
+    this.material?.uniforms.resolution.value.set(1 / width, 1 / height);
+  }
+
+  render(gradeScene, camera) {
+    const renderer = this.renderer;
+    renderer.setRenderTarget(this.target);
+    renderer.clear();
+    renderer.render(gradeScene, camera);
+    if (this.target) {
+      this.material.uniforms.tDiffuse.value = this.target.texture;
+      renderer.setRenderTarget(null);
+      renderer.clear();
+      renderer.render(this.scene, camera);
+    }
+  }
+
+  getState() {
+    return { antialiasing: this.mode, samples: this.mode === 'msaa' ? this.samples : 0,
+      supportedSamples: this.samples, filteredTextures: this.filteredTextures };
+  }
+}

--- a/export/web/graphics-settings.js
+++ b/export/web/graphics-settings.js
@@ -1,0 +1,119 @@
+const PRESETS = Object.freeze({
+  auto: { ratio: 1.5, pixels: 1440000, anisotropy: 4 },
+  performance: { ratio: 1, pixels: 900000, anisotropy: 2 },
+  quality: { ratio: 2, pixels: 1800000, anisotropy: 8 },
+});
+const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+const positive = (n, fallback) => Number.isFinite(n) && n > 0 ? n : fallback;
+
+// Resolution follows sustained frame intervals, including GPU work between
+// animation frames. It never uses the simulation's deliberately clamped dt.
+export class GraphicsSettings {
+  constructor({ mobile = false, preset = 'auto' } = {}) {
+    this.mobile = mobile;
+    this.preset = Object.hasOwn(PRESETS, preset) ? preset : 'auto';
+    this.autoRatio = PRESETS.auto.ratio;
+    this.width = this.height = this.dpr = 1;
+    this.maxSize = 16384;
+    this.resetTiming();
+  }
+
+  setPreset(preset) {
+    if (!Object.hasOwn(PRESETS, preset)) return false;
+    this.preset = preset;
+    this.autoRatio = PRESETS.auto.ratio;
+    this.resetTiming();
+    return true;
+  }
+
+  setViewport(width, height, dpr, maxSize = 16384) {
+    this.width = positive(width, 1);
+    this.height = positive(height, 1);
+    this.dpr = positive(dpr, 1);
+    this.maxSize = positive(maxSize, 16384);
+    // Preserve a learned scale through rotation, but discard its timing window.
+    this.resetTiming();
+  }
+
+  get pixelRatio() {
+    const preset = PRESETS[this.preset];
+    const desired = this.mobile ? (this.preset === 'auto' ? this.autoRatio : preset.ratio) : 1;
+    const budget = this.mobile ? preset.pixels : 1440000;
+    return Math.min(desired, this.dpr, Math.sqrt(budget / (this.width * this.height)),
+      this.maxSize / this.width, this.maxSize / this.height);
+  }
+
+  get antialias() { return this.mobile && this.preset !== 'performance'; }
+  get anisotropy() { return this.mobile ? PRESETS[this.preset].anisotropy : 1; }
+
+  resetTiming() {
+    this.previous = null;
+    this.warmup = 1000;
+    this.elapsed = this.frames = this.slowWindows = this.fastWindows = 0;
+  }
+
+  observeFrame(now, active) {
+    if (!active || !this.mobile || this.preset !== 'auto' || !Number.isFinite(now)) {
+      this.resetTiming();
+      return false;
+    }
+    const previous = this.previous;
+    this.previous = now;
+    if (previous === null) return false;
+    const dt = now - previous;
+    // Hidden tabs, debugger stops, and loading stalls must not lower quality.
+    if (dt <= 0 || dt > 1000) { this.resetTiming(); return false; }
+    if (this.warmup > 0) { this.warmup -= dt; return false; }
+    this.elapsed += dt;
+    this.frames++;
+    if (this.elapsed < 1000) return false;
+    const average = this.elapsed / this.frames;
+    this.elapsed = this.frames = 0;
+    this.slowWindows = average > 22 ? this.slowWindows + 1 : 0;
+    this.fastWindows = average < 17.5 ? this.fastWindows + 1 : 0;
+    const before = this.pixelRatio;
+    if (this.slowWindows >= 2) {
+      // If a tablet's pixel budget already limits the scale, lower from its
+      // effective resolution instead of spending steps above that ceiling.
+      this.autoRatio = Math.max(0.75, Math.min(this.autoRatio, before) - 0.125);
+      this.slowWindows = this.fastWindows = 0;
+    } else if (this.fastWindows >= 6) {
+      this.autoRatio = clamp(this.autoRatio + 0.125, 0.75, PRESETS.auto.ratio);
+      this.slowWindows = this.fastWindows = 0;
+    }
+    return Math.abs(before - this.pixelRatio) > 0.001;
+  }
+
+  getState() {
+    return { preset: this.preset, mobile: this.mobile, adaptive: this.mobile && this.preset === 'auto',
+      pixelRatio: Number(this.pixelRatio.toFixed(3)), anisotropy: this.anisotropy };
+  }
+}
+
+// Color and depth attachments must both support the requested sample count.
+// Some GPUs offer four samples but not two for the half-float HDR target.
+export function chooseSamples(colorSamples = [], depthSamples = []) {
+  return [...colorSamples].filter(n => n >= 2 && n <= 4 && [...depthSamples].includes(n))
+    .sort((a, b) => a - b)[0] ?? 0;
+}
+
+export function filterTextures(root, requested, maximum = 1) {
+  const anisotropy = Math.max(1, Math.min(requested, maximum));
+  const seen = new Set();
+  root.traverse(object => {
+    const materials = Array.isArray(object.material) ? object.material : [object.material];
+    for (const material of materials) {
+      if (!material) continue;
+      for (const key of ['map', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap', 'bumpMap']) {
+        const texture = material[key];
+        if (!texture?.isTexture || seen.has(texture)) continue;
+        seen.add(texture);
+        if (texture.anisotropy !== anisotropy) {
+          texture.anisotropy = anisotropy;
+          texture.needsUpdate = true;
+        }
+      }
+    }
+  });
+  return seen.size;
+}

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<link rel="stylesheet" href="touch-controls.css">
 <link rel="icon" href="social/icon-512.png" type="image/png">
 <link rel="apple-touch-icon" href="social/icon-512.png">
 <title>Claude of Duty: Vibe Slops II</title>
@@ -555,6 +556,12 @@
       </div>
     </section>
     <pre class="fe-controls" id="fe-controls"></pre>
+    <div class="touch-only touch-settings" id="touch-settings">
+      <label for="touch-sensitivity">Look sensitivity <input id="touch-sensitivity" type="range" min="0.4" max="2" step="0.1" value="1"><output id="touch-sensitivity-value" for="touch-sensitivity">1.0×</output></label>
+      <p>Push the stick forward to sprint. Tap aim and crouch to toggle.</p>
+      <p>Landscape gives you more room to aim.</p>
+      <button type="button" class="fe-btn" id="touch-fullscreen" hidden>Full screen</button>
+    </div>
     <p class="fe-message" id="fe-message"></p>
   </div>
 </div>
@@ -575,6 +582,8 @@
     <p id="match-result"></p>
     <div class="scoreboard-row head"><span>#</span><span>Player</span><span>Kills</span><span>Deaths</span></div>
     <div id="scoreboard-rows"></div>
+    <button type="button" class="fe-btn touch-only" id="touch-score-close">Back to game</button>
+    <button type="button" class="fe-btn touch-only" id="touch-restart" hidden>Play again</button>
   </div>
 </div>
 <div id="crosshair"></div>
@@ -585,6 +594,20 @@
   <line x1="23" y1="23" x2="17" y2="17"></line>
 </svg>
 <div id="damage"></div>
+<div id="touch-controls" hidden aria-label="Touch controls">
+  <div class="touch-look" data-touch="look" aria-label="Swipe to look"></div>
+  <div class="touch-move" data-touch="move" aria-label="Drag to move; push forward to sprint">
+    <div class="touch-stick"><div class="touch-knob"></div><span>MOVE</span></div>
+  </div>
+  <span class="touch-hint">SWIPE TO LOOK · DRAG FIRE TO AIM</span>
+  <button type="button" class="touch-button touch-fire" data-touch="fire" aria-label="Hold to fire; drag to aim"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="2"/><path d="M12 1v5m0 12v5M1 12h5m12 0h5"/></svg><span>FIRE</span></button>
+  <button type="button" class="touch-button touch-aim" data-touch="aim" aria-label="Toggle aim down sights" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5M12 7v10M7 12h10"/></svg><span>AIM</span></button>
+  <button type="button" class="touch-button touch-jump" data-touch="jump" aria-label="Jump"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 10 6-6 6 6M12 4v14M4 21h16"/></svg><span>JUMP</span></button>
+  <button type="button" class="touch-button touch-crouch" data-touch="crouch" aria-label="Toggle crouch" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="14" cy="4" r="2"/><path d="m12 8-3 5 7 2-2 6m-3-11 5 2h4M9 13l-5 5h6"/></svg><span>CROUCH</span></button>
+  <button type="button" class="touch-button touch-reload" data-touch="reload" aria-label="Reload"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 10a8 8 0 1 0-2 8M20 4v6h-6"/></svg><span>RELOAD</span></button>
+  <button type="button" class="touch-button touch-scores" id="touch-scores" aria-label="Show scoreboard"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20V10h4v10m2 0V4h4v16m2 0V7h4v13"/></svg></button>
+  <button type="button" class="touch-button touch-pause" id="touch-pause" aria-label="Pause game"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14M16 5v14"/></svg></button>
+</div>
 <script type="module">
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -602,6 +625,7 @@ import { FreeForAllMatch } from './free-for-all-match.js';
 import { MedalTracker } from './medals.js';
 import { Hud } from './hud.js';
 import { Frontend } from './frontend.js';
+import { TouchControls } from './touch-controls.js';
 import { PlayCounter } from './play-counter.js';
 import { loadCollisionWorld } from './collision-world.js';
 import { optimizeStaticScene } from './scene-optimizer.js';
@@ -1076,8 +1100,8 @@ const frontend = new Frontend({
     classConfirm: blocker.querySelector('[data-action="class-confirm"]'),
     onAction: (name) => menuAction(name),
   },
-  onPlay: () => renderer.domElement.requestPointerLock(),
-  onResume: () => renderer.domElement.requestPointerLock(),
+  onPlay: () => requestPlay(),
+  onResume: () => requestPlay(),
   onSelectWeapon: (id) => selectWeapon(id),
   onOpenClass: () => loadAllWeaponSlots(),
 });
@@ -1168,6 +1192,8 @@ const yawPitch = new THREE.Euler(0, 0, 0, 'YXZ');
 
 let ready = false;
 let locked = false;
+let mouseFire = false;
+let mouseAim = false;
 let player = null;
 let navigation = null;
 let collisionRoot = null;
@@ -1197,6 +1223,129 @@ const MEDAL_FADE_SECONDS = 0.45;
 
 const match = new FreeForAllMatch({ scoreLimit: 30, timeLimitSeconds: 300 });
 match.register('player', 'YOU', { human: true });
+
+const touchControls = new TouchControls({
+  root: document.getElementById('touch-controls'),
+  onLook: (x, y, sensitivity) => {
+    if (!canControlPlayer()) return;
+    // CSS pixels make the same thumb gesture independent of device DPI.
+    applyLook(x, y, 0.005 * sensitivity * (viewmodel.aiming ? 0.5 : 1));
+  },
+  onAction: (action) => { if (canControlPlayer() && action === 'reload') reloadWeapon(); },
+  onModeChange: () => updateControlHints(),
+});
+const touchSensitivity = document.getElementById('touch-sensitivity');
+const sensitivityValue = document.getElementById('touch-sensitivity-value');
+touchSensitivity.value = touchControls.sensitivity;
+sensitivityValue.textContent = `${touchControls.sensitivity.toFixed(1)}×`;
+document.getElementById('touch-settings').addEventListener('click', event => event.stopPropagation());
+touchSensitivity.addEventListener('input', () => {
+  touchControls.setSensitivity(touchSensitivity.value);
+  sensitivityValue.textContent = `${touchControls.sensitivity.toFixed(1)}×`;
+});
+const fullscreenButton = document.getElementById('touch-fullscreen');
+fullscreenButton.hidden = !document.fullscreenEnabled;
+fullscreenButton.addEventListener('click', async () => {
+  try {
+    if (document.fullscreenElement) await document.exitFullscreen();
+    else await document.documentElement.requestFullscreen();
+  } catch { /* Playing in the browser remains available when full screen is denied. */ }
+});
+document.addEventListener('fullscreenchange', () => {
+  fullscreenButton.textContent = document.fullscreenElement ? 'Exit full screen' : 'Full screen';
+});
+// Secondary touch contacts do not consistently synthesize clicks. Menu
+// shortcuts must still work while the other thumb is holding movement/fire.
+let suppressShortcutClick = false;
+document.addEventListener('pointerdown', () => { suppressShortcutClick = false; }, true);
+document.addEventListener('click', (event) => {
+  if (!suppressShortcutClick) return;
+  suppressShortcutClick = false;
+  if (event.detail === 0) return;
+  // Opening the menu under a finger can retarget its later compatibility
+  // click to the shell and immediately resume. Consume that same gesture;
+  // a fresh pointerdown always starts a new, independent menu interaction.
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}, true);
+function bindTouchShortcut(id, action) {
+  const button = document.getElementById(id);
+  button.addEventListener('pointerdown', (event) => {
+    if (event.pointerType !== 'touch') return;
+    event.preventDefault();
+    suppressShortcutClick = true;
+    action();
+  });
+  button.addEventListener('click', (event) => {
+    if (event.pointerType === 'touch' || event.sourceCapabilities?.firesTouchEvents) return;
+    action();
+  });
+}
+bindTouchShortcut('touch-pause', () => suspendPlay());
+bindTouchShortcut('touch-scores', () => {
+  clearKeys();
+  scoreboardHeld = true;
+  renderMatchUi();
+});
+document.getElementById('touch-score-close').addEventListener('click', () => {
+  scoreboardHeld = false;
+  renderMatchUi();
+});
+document.getElementById('touch-restart').addEventListener('click', () => {
+  restartMatch();
+  requestPlay();
+});
+
+function canControlPlayer() {
+  return ready && locked && !frontend.visible && !automationPaused &&
+    !(touchControls.mode && scoreboardHeld) && match.phase === 'playing' && !playerHealth?.dead;
+}
+
+function applyLook(x, y, sensitivity = 0.0022) {
+  yawPitch.setFromQuaternion(camera.quaternion);
+  yawPitch.y -= x * sensitivity;
+  yawPitch.x = THREE.MathUtils.clamp(yawPitch.x - y * sensitivity, -Math.PI / 2, Math.PI / 2);
+  camera.quaternion.setFromEuler(yawPitch);
+  viewmodel.addLook(x, y);
+}
+
+function requestPlay() {
+  if (!ready) return;
+  const audio = weaponEffects.audio.ensureContext();
+  if (audio?.state === 'suspended') void audio.resume().catch(() => {});
+  // Menu buttons must not retain keyboard focus over gameplay.
+  document.activeElement?.blur();
+  if (touchControls.mode) {
+    setAutomationActive(true);
+    playCounter.record().then(renderPlayCount);
+  } else {
+    renderer.domElement.requestPointerLock()?.catch(() => frontend.suspend());
+  }
+}
+
+function suspendPlay() {
+  clearKeys();
+  if (!locked) return;
+  setAutomationActive(false);
+  if (document.pointerLockElement) document.exitPointerLock();
+}
+
+function updateControlHints() {
+  if (!ready) return;
+  frontend.controls = touchControls.mode ? [
+    'Left thumb move · Right thumb swipe to look',
+    'Hold FIRE and drag to aim · JUMP · RELOAD',
+    'Pause for classes and sensitivity · Scores at top right',
+  ] : [
+    'WASD move · Shift sprint · Space jump · C/Ctrl crouch',
+    'Left mouse fire · Right mouse aim · R reload · B respawn',
+    '1 M27 · 2 AN-94 · Create a class from the menu',
+    'K cycle camo · N navmesh · V collision · P path · Esc pause',
+  ];
+  frontend.render();
+  const prompt = document.querySelector('.fe-prompt');
+  if (prompt && touchControls.mode) prompt.textContent = 'Tap to deploy';
+}
 
 const weaponEffects = new WeaponEffects(scene);
 // Reload audio is authored into the clip as notetracks, so the cues play from
@@ -1307,6 +1456,7 @@ function combatantId(actor) {
 }
 
 function resetPlayerLife() {
+  clearKeys();
   const spawn = enemies?.safeSpawnFor(player);
   if (spawn) {
     player.setSpawn(spawn.position, { eye: false });
@@ -1368,8 +1518,10 @@ function renderMatchUi() {
   }));
   const winner = state.standings.find((entry) => entry.id === state.winnerId);
   matchResult.textContent = state.phase === 'ended'
-    ? `${winner?.id === 'player' ? 'VICTORY' : `${winner?.name ?? 'Unknown'} wins`} · press Enter to play again`
-    : `First to ${state.scoreLimit} kills · hold Tab for scores`;
+    ? `${winner?.id === 'player' ? 'VICTORY' : `${winner?.name ?? 'Unknown'} wins`}${touchControls.mode ? '' : ' · press Enter to play again'}`
+    : `First to ${state.scoreLimit} kills${touchControls.mode ? '' : ' · hold Tab for scores'}`;
+  document.getElementById('touch-restart').hidden = state.phase !== 'ended';
+  document.getElementById('touch-score-close').hidden = state.phase === 'ended';
   scoreboard.classList.toggle('visible', scoreboardHeld || state.phase === 'ended');
 }
 
@@ -1488,6 +1640,10 @@ function showPathToCrosshair() {
 
 function clearKeys() {
   for (const code of Object.keys(keys)) keys[code] = false;
+  mouseFire = mouseAim = false;
+  touchControls.reset();
+  weapon?.setTrigger(false);
+  viewmodel.setAiming(false);
 }
 
 // A kill marker outlives a body marker so the confirmation still reads when
@@ -1585,6 +1741,7 @@ function getDebugState() {
     ready,
     active: locked,
     paused: automationPaused,
+    input: { touch: touchControls.getState() },
     player: player ? {
       feet: debugVector(feet),
       eye: debugVector(player.position),
@@ -1682,6 +1839,13 @@ function getDebugState() {
 function createDebugApi() {
   return {
     getState: getDebugState,
+    // Exercise the post-match shell without waiting for the five-minute clock.
+    finishMatch() {
+      match.finish();
+      clearKeys();
+      renderMatchUi();
+      return match.getState();
+    },
     // Rifles other than the equipped one load from the class screen, which
     // automation never opens. Awaiting this is the scripted equivalent.
     loadAllWeapons: () => loadAllWeaponSlots(),
@@ -1778,6 +1942,7 @@ function createDebugApi() {
 }
 
 document.addEventListener('pointerlockchange', () => {
+  if (touchControls.mode && !document.pointerLockElement) return;
   locked = document.pointerLockElement === renderer.domElement;
   document.body.classList.toggle('locked', locked);
   // Counting here rather than in `frontend.enter()` keeps the automation
@@ -1795,34 +1960,35 @@ document.addEventListener('pointerlockchange', () => {
 });
 
 document.addEventListener('mousemove', (event) => {
-  if (!locked) return;
-  yawPitch.setFromQuaternion(camera.quaternion);
-  yawPitch.y -= event.movementX * 0.0022;
-  yawPitch.x -= event.movementY * 0.0022;
-  yawPitch.x = THREE.MathUtils.clamp(yawPitch.x, -Math.PI / 2, Math.PI / 2);
-  camera.quaternion.setFromEuler(yawPitch);
-  viewmodel.addLook(event.movementX, event.movementY);
+  if (!canControlPlayer() || event.sourceCapabilities?.firesTouchEvents) return;
+  applyLook(event.movementX, event.movementY);
 });
 
 document.addEventListener('mousedown', (event) => {
-  if (!locked) return;
-  if (event.button === 0) weapon.setTrigger(true);
-  if (event.button === 2) viewmodel.setAiming(true);
+  if (!canControlPlayer() || event.sourceCapabilities?.firesTouchEvents || event.target.closest('#touch-controls')) return;
+  if (event.button === 0) { mouseFire = true; weapon.setTrigger(true); }
+  if (event.button === 2) { mouseAim = true; viewmodel.setAiming(true); }
 });
 document.addEventListener('mouseup', (event) => {
-  if (event.button === 0) weapon.setTrigger(false);
-  if (event.button === 2) viewmodel.setAiming(false);
+  if (event.sourceCapabilities?.firesTouchEvents) return;
+  if (event.button === 0) { mouseFire = false; weapon.setTrigger(false); }
+  if (event.button === 2) { mouseAim = false; viewmodel.setAiming(false); }
 });
 document.addEventListener('contextmenu', (event) => {
   if (locked) event.preventDefault();
 });
 
 document.addEventListener('keydown', (event) => {
+  if (event.target.matches('input, select, textarea, button')) return;
   keys[event.code] = true;
   if (['Space', 'Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.code)) {
     event.preventDefault();
   }
   if (event.repeat || !ready) return;
+  if (event.code === 'Escape' && locked && touchControls.mode) {
+    suspendPlay();
+    return;
+  }
   if (event.code === 'Enter' && match.phase === 'ended') {
     restartMatch();
     return;
@@ -1865,6 +2031,9 @@ document.addEventListener('keyup', (event) => {
     renderMatchUi();
   }
 });
+addEventListener('blur', () => suspendPlay());
+addEventListener('pagehide', () => suspendPlay());
+document.addEventListener('visibilitychange', () => { if (document.hidden) suspendPlay(); });
 
 async function start() {
   try {
@@ -1944,6 +2113,7 @@ async function start() {
       regenDelay: 4,
       regenPerSecond: 25,
       onDeath: ({ source }) => {
+        clearKeys();
         deathSource = source;
         match.recordKill(combatantId(source), 'player');
         medals?.onDeath();
@@ -2067,6 +2237,7 @@ async function start() {
       'K cycle camo · N navmesh · V collision · P path · Esc pause',
       navigation ? '' : 'Navigation failed to load; collision and walking are still available.',
     ]);
+    updateControlHints();
   } catch (error) {
     console.error(error);
     frontend.fail(`Unable to start\n${error instanceof Error ? error.message : error}`);
@@ -2078,16 +2249,22 @@ function tick() {
   requestAnimationFrame(tick);
   const frameWorkStartedAt = performance.now();
   const dt = Math.min(clock.getDelta(), 0.1);
-  const simulationActive = locked && !automationPaused && match.phase === 'playing';
+  const simulationActive = locked && !frontend.visible && !automationPaused &&
+    !(touchControls.mode && scoreboardHeld) && match.phase === 'playing';
+  const controlsActive = canControlPlayer();
+  touchControls.setEnabled(controlsActive, ready && locked && !frontend.visible && !scoreboardHeld && match.phase === 'playing');
+  const touch = touchControls.input.read();
+  const movement = {
+    forward: Number(Boolean(keys.KeyW)) - Number(Boolean(keys.KeyS)) + touch.forward,
+    strafe: Number(Boolean(keys.KeyD)) - Number(Boolean(keys.KeyA)) + touch.strafe,
+    sprint: Boolean(keys.ShiftLeft || keys.ShiftRight || touch.sprint),
+    crouch: Boolean(keys.ControlLeft || keys.ControlRight || keys.KeyC || touch.crouch),
+    jump: Boolean(keys.Space || touch.jump),
+  };
+  weapon.setTrigger(controlsActive && (mouseFire || touch.fire));
+  viewmodel.setAiming(controlsActive && (mouseAim || touch.aim));
   if (player && simulationActive) {
-    player.update(dt, {
-      forward: keys.KeyW,
-      backward: keys.KeyS,
-      strafe: Number(Boolean(keys.KeyD)) - Number(Boolean(keys.KeyA)),
-      sprint: keys.ShiftLeft || keys.ShiftRight,
-      crouch: keys.ControlLeft || keys.ControlRight || keys.KeyC,
-      jump: keys.Space,
-    });
+    player.update(dt, controlsActive ? movement : {});
   }
   if (simulationActive) navigation?.update(1 / 60, dt, 5);
   enemies?.update(dt, { active: simulationActive });
@@ -2100,8 +2277,8 @@ function tick() {
   if (player) {
     const p = player.position;
     const speed = Math.hypot(player.velocity.x, player.velocity.z);
-    const moving = Boolean(keys.KeyW || keys.KeyA || keys.KeyS || keys.KeyD);
-    const sprinting = Boolean(keys.ShiftLeft || keys.ShiftRight) && moving;
+    const moving = controlsActive && Math.hypot(movement.forward, movement.strafe) > 0;
+    const sprinting = movement.sprint && moving;
 
     viewmodel.update(dt, {
       speed,
@@ -2177,6 +2354,7 @@ function tick() {
     }
   }
   if (match.phase === 'ended' && !matchEndedHandled) {
+    clearKeys();
     matchEndedHandled = true;
     player?.setEnabled(false);
     weapon.setTrigger(false);

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -562,6 +562,8 @@
     </section>
     <pre class="fe-controls" id="fe-controls"></pre>
     <div class="touch-only touch-settings" id="touch-settings">
+      <label for="touch-graphics">Graphics <select id="touch-graphics"><option value="auto">Auto</option><option value="performance">Performance</option><option value="quality">Quality</option></select></label>
+      <p id="touch-graphics-hint">Balances sharpness and smooth play.</p>
       <label for="touch-sensitivity">Look sensitivity <input id="touch-sensitivity" type="range" min="0.4" max="2" step="0.1" value="1"><output id="touch-sensitivity-value" for="touch-sensitivity">1.0×</output></label>
       <p>Push the stick forward to sprint. Tap aim and crouch to toggle.</p>
       <p>Landscape gives you more room to aim.</p>
@@ -647,6 +649,8 @@ import { MedalTracker } from './medals.js';
 import { Hud } from './hud.js';
 import { Frontend } from './frontend.js';
 import { TouchControls } from './touch-controls.js';
+import { GraphicsSettings, filterTextures } from './graphics-settings.js';
+import { GraphicsRenderer } from './graphics-renderer.js';
 import { PlayCounter } from './play-counter.js';
 import { loadCollisionWorld } from './collision-world.js';
 import { optimizeStaticScene } from './scene-optimizer.js';
@@ -660,20 +664,22 @@ scene.fog = new THREE.Fog(0x87a8c8, HAZE.near, HAZE.far);
 const camera = new THREE.PerspectiveCamera(75, innerWidth / innerHeight, 1, 20000);
 camera.rotation.order = 'YXZ';
 
-const MAX_RENDER_PIXELS = 1600 * 900;
-const renderPixelRatio = () => Math.max(0.5, Math.min(
-  devicePixelRatio,
-  1,
-  Math.sqrt(MAX_RENDER_PIXELS / Math.max(1, innerWidth * innerHeight)),
-));
+let savedGraphics = 'auto';
+try { savedGraphics = localStorage.getItem('hijacked.graphics') ?? 'auto'; } catch {}
+const graphics = new GraphicsSettings({ mobile: matchMedia('(pointer: coarse)').matches, preset: savedGraphics });
 const renderer = new THREE.WebGLRenderer({
   antialias: false,
   powerPreference: 'high-performance',
 });
 renderer.setSize(innerWidth, innerHeight);
-renderer.setPixelRatio(renderPixelRatio());
+const gl = renderer.getContext();
+const maxRenderSize = Math.min(renderer.capabilities.maxTextureSize,
+  gl.getParameter(gl.MAX_RENDERBUFFER_SIZE), ...gl.getParameter(gl.MAX_VIEWPORT_DIMS));
+graphics.setViewport(innerWidth, innerHeight, devicePixelRatio, maxRenderSize);
+renderer.setPixelRatio(graphics.pixelRatio);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 renderer.autoClear = false;
+const graphicsRenderer = new GraphicsRenderer(renderer);
 document.body.appendChild(renderer.domElement);
 
 const VIEWMODEL_HANDS = 'viewmodel/c_usa_mp_fbi_shortsleeve_viewhands_lod0.glb';
@@ -1021,6 +1027,36 @@ function sizeGradeTarget() {
   if (!gradeTarget) return;
   const ratio = renderer.getPixelRatio();
   gradeTarget.setSize(Math.floor(innerWidth * ratio), Math.floor(innerHeight * ratio));
+  graphicsRenderer.setSize(gradeTarget.width, gradeTarget.height);
+}
+
+function resizeGraphicsBuffer() {
+  // Change only the drawing buffer, preserving CSS touch coordinates and
+  // pointer capture while Auto adjusts resolution during a thumb gesture.
+  renderer.setDrawingBufferSize(innerWidth, innerHeight, graphics.pixelRatio);
+  sizeGradeTarget();
+}
+
+function refreshTextureFiltering() {
+  const maximum = renderer.capabilities.getMaxAnisotropy();
+  graphicsRenderer.filteredTextures = filterTextures(scene, graphics.anisotropy, maximum);
+  for (const slot of weaponSlots.values()) {
+    graphicsRenderer.filteredTextures += filterTextures(slot.viewmodel.scene, graphics.anisotropy, maximum);
+  }
+}
+
+function applyGraphicsSettings() {
+  resizeGraphicsBuffer();
+  if (gradeTarget) graphicsRenderer.configure(graphics.antialias, gradeTarget);
+  refreshTextureFiltering();
+}
+
+function setGraphicsPreset(preset) {
+  if (!graphics.setPreset(preset)) return false;
+  try { localStorage.setItem('hijacked.graphics', graphics.preset); } catch {}
+  applyGraphicsSettings();
+  renderGraphicsSettings();
+  return graphics.preset;
 }
 
 loadGradeLut().then((lut) => {
@@ -1033,6 +1069,7 @@ loadGradeLut().then((lut) => {
   gradeTarget.texture.minFilter = THREE.LinearFilter;
   gradeTarget.texture.magFilter = THREE.LinearFilter;
   sizeGradeTarget();
+  graphicsRenderer.configure(graphics.antialias, gradeTarget);
   gradeMaterial = new THREE.ShaderMaterial({
     ...POST_SHADER,
     uniforms: THREE.UniformsUtils.clone(POST_SHADER.uniforms),
@@ -1254,8 +1291,23 @@ const touchControls = new TouchControls({
     applyLook(x, y, 0.005 * sensitivity * (viewmodel.aiming ? 0.5 : 1));
   },
   onAction: (action) => { if (canControlPlayer() && action === 'reload') reloadWeapon(); },
-  onModeChange: () => updateControlHints(),
+  onModeChange: () => {
+    graphics.mobile = true;
+    applyGraphicsSettings();
+    updateControlHints();
+  },
 });
+const graphicsSelect = document.getElementById('touch-graphics');
+function renderGraphicsSettings() {
+  graphicsSelect.value = graphics.preset;
+  document.getElementById('touch-graphics-hint').textContent = {
+    auto: 'Balances sharpness and smooth play.',
+    performance: 'Lighter graphics for smoother play.',
+    quality: 'Sharper detail and smoother edges. Uses more battery.',
+  }[graphics.preset];
+}
+renderGraphicsSettings();
+graphicsSelect.addEventListener('change', () => setGraphicsPreset(graphicsSelect.value));
 const touchSensitivity = document.getElementById('touch-sensitivity');
 const sensitivityValue = document.getElementById('touch-sensitivity-value');
 touchSensitivity.value = touchControls.sensitivity;
@@ -1414,6 +1466,7 @@ function loadWeaponSlot(slot) {
         },
       );
       await slotViewmodel.loadClips(definition.clips);
+      filterTextures(slotViewmodel.scene, graphics.anisotropy, renderer.capabilities.getMaxAnisotropy());
       frontend.setWeaponReady(definition.id, true);
     } catch (error) {
       frontend.setWeaponReady(definition.id, false);
@@ -1847,6 +1900,9 @@ function getDebugState() {
       textures: renderer.info.memory.textures,
       drawingBuffer: [size.x, size.y],
       pixelRatio: debugRound(renderer.getPixelRatio()),
+      graphics: { ...graphics.getState(), ...graphicsRenderer.getState(),
+        sceneBuffer: gradeTarget ? [gradeTarget.width, gradeTarget.height] : null,
+        anisotropy: Math.max(1, Math.min(graphics.anisotropy, renderer.capabilities.getMaxAnisotropy())) },
       frameWork: frameWorkStats(),
       collision: collisionWorld?.stats ?? null,
       scene: mapOptimization,
@@ -1861,6 +1917,7 @@ function getDebugState() {
 function createDebugApi() {
   return {
     getState: getDebugState,
+    setGraphicsPreset,
     // Exercise the post-match shell without waiting for the five-minute clock.
     finishMatch() {
       match.finish();
@@ -1925,7 +1982,9 @@ function createDebugApi() {
       return selectWeapon(id);
     },
     setWeaponCamo(name) {
-      return viewmodel.setCamo(String(name)) ? viewmodel.camo : false;
+      const changed = viewmodel.setCamo(String(name));
+      if (changed) refreshTextureFiltering();
+      return changed ? viewmodel.camo : false;
     },
     respawnPlayer() {
       playerHealth?.respawn();
@@ -2040,7 +2099,7 @@ document.addEventListener('keydown', (event) => {
     setDebugVisibility();
   }
   if (event.code === 'KeyP') showPathToCrosshair();
-  if (event.code === 'KeyK' && locked) viewmodel.cycleCamo();
+  if (event.code === 'KeyK' && locked) { viewmodel.cycleCamo(); refreshTextureFiltering(); }
   if (event.code === 'Tab') {
     scoreboardHeld = true;
     renderMatchUi();
@@ -2177,6 +2236,7 @@ async function start() {
     ).finally(() => frontend.stage('enemy'));
 
     await Promise.all([viewmodelPromise, weaponEffects.loadAudio(), enemyPromise, loadEnvironment()]);
+    refreshTextureFiltering();
 
     const botNames = ['ADMIRAL', 'CORSAIR', 'DEADEYE', 'MARINER', 'ROGUE', 'VIPER'];
     for (const enemy of enemies?.enemies ?? []) {
@@ -2235,6 +2295,9 @@ async function start() {
       parent.add(warmEnemy.root);
     }
     frontend.stage('shaders');
+    // Prime the post-processing buffers once before deployment. The opaque
+    // frontend covers the canvas, so it does not need a full scene every frame.
+    renderFrame();
 
     // Small read/debug surface for automated smoke tests and map tooling.
     globalThis.hijacked = {
@@ -2270,6 +2333,7 @@ async function start() {
 function tick() {
   requestAnimationFrame(tick);
   const frameWorkStartedAt = performance.now();
+  if (graphics.observeFrame(frameWorkStartedAt, ready && canControlPlayer() && !document.hidden)) resizeGraphicsBuffer();
   const dt = Math.min(clock.getDelta(), 0.1);
   const simulationActive = locked && !frontend.visible && !automationPaused &&
     !(touchControls.mode && scoreboardHeld) && match.phase === 'playing';
@@ -2405,9 +2469,11 @@ function tick() {
   updateLightProbes(camera.position);
   // The stride bob lives on the camera only for the draw; gameplay reads the
   // steady camera before and after.
-  viewBob.apply(camera);
-  renderFrame();
-  viewBob.restore(camera);
+  if (!frontend.visible) {
+    viewBob.apply(camera);
+    renderFrame();
+    viewBob.restore(camera);
+  }
   if (ready && performance.now() >= frameWorkWarmupUntil) {
     frameWorkSamples[frameWorkSampleIndex] = performance.now() - frameWorkStartedAt;
     frameWorkSampleIndex = (frameWorkSampleIndex + 1) % frameWorkSamples.length;
@@ -2415,8 +2481,8 @@ function tick() {
   }
 }
 
-// With the grade active the world and viewmodel go into an sRGB-encoded target
-// and the LUT pass writes the canvas; without it they draw straight to screen.
+// The world and weapon share the HDR scene target. Grade once, then use FXAA
+// only when the device cannot multisample that target.
 function renderFrame() {
   if (gradeMaterial && gradeTarget) {
     // Kept in sync here because the vision set's exposure is applied
@@ -2426,10 +2492,8 @@ function renderFrame() {
     renderer.clear();
     renderer.render(scene, camera);
     viewmodel.render(renderer);
-    renderer.setRenderTarget(null);
     gradeMaterial.uniforms.tDiffuse.value = gradeTarget.texture;
-    renderer.clear();
-    renderer.render(gradeScene, gradeCamera);
+    graphicsRenderer.render(gradeScene, gradeCamera);
     return;
   }
   renderer.clear();
@@ -2456,9 +2520,9 @@ addEventListener('resize', () => {
   camera.aspect = innerWidth / innerHeight;
   camera.updateProjectionMatrix();
   for (const slot of weaponSlots.values()) slot.viewmodel.setSize(innerWidth, innerHeight);
-  renderer.setPixelRatio(renderPixelRatio());
+  graphics.setViewport(innerWidth, innerHeight, devicePixelRatio, maxRenderSize);
   renderer.setSize(innerWidth, innerHeight);
-  sizeGradeTarget();
+  resizeGraphicsBuffer();
 });
 </script>
 </body>

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -109,7 +109,7 @@
 
   .fe-track {
     width: min(430px, 80vw); height: 6px; background: rgba(255, 255, 255, .1);
-    border: 1px solid rgba(255, 255, 255, .18);
+    border: 1px solid rgba(255, 255, 255, .18); overflow: hidden;
   }
   .fe-bar {
     height: 100%; width: 0; background: var(--fe-accent);
@@ -273,7 +273,9 @@
   .fe-message { margin: 0; max-width: 46ch; color: #ff9b90; white-space: pre-line; }
 
   /* One screen at a time; `render()` sets data-screen on the root. */
-  .fe-load, .fe-start, .fe-pause, .fe-class, .fe-controls, .fe-message { display: none; }
+  .fe-welcome, .fe-load, .fe-start, .fe-pause, .fe-class, .fe-controls, .fe-message { display: none; }
+  #blocker[data-screen="welcome"] .fe-welcome { display: block; }
+  #fe-load-game { min-height: 48px; height: auto; line-height: 48px; touch-action: manipulation; }
   #blocker[data-screen="loading"] .fe-load { display: block; }
   #blocker[data-screen="title"] .fe-start,
   #blocker[data-screen="pause"] .fe-pause { display: flex; flex-direction: column; align-items: center; gap: 22px; }
@@ -468,7 +470,7 @@
 </script>
 </head>
 <body>
-<div id="blocker" data-screen="loading">
+<div id="blocker" data-screen="welcome">
   <div class="fe-layer fe-backdrop"></div>
   <div class="fe-layer fe-fog"></div>
   <div class="fe-layer fe-fog slow"></div>
@@ -479,9 +481,12 @@
       <h1 class="fe-wordmark">CLAUDE OF DUTY<span class="fe-subtitle">VIBE SLOPS <b>II</b></span></h1>
       <p class="fe-sub">Browser reconstruction</p>
     </header>
+    <div class="fe-welcome">
+      <button type="button" class="fe-btn" id="fe-load-game">Tap or click to load</button>
+    </div>
     <div class="fe-load">
       <div class="fe-track"><div class="fe-bar" id="fe-bar"></div></div>
-      <div class="fe-status"><span id="fe-caption"></span><span id="fe-percent"></span></div>
+      <div class="fe-status"><span id="fe-caption">Preparing game…</span><span id="fe-percent"></span></div>
     </div>
     <div class="fe-start">
       <figure class="fe-card">
@@ -608,6 +613,22 @@
   <button type="button" class="touch-button touch-scores" id="touch-scores" aria-label="Show scoreboard"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20V10h4v10m2 0V4h4v16m2 0V7h4v13"/></svg></button>
   <button type="button" class="touch-button touch-pause" id="touch-pause" aria-label="Pause game"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14M16 5v14"/></svg></button>
 </div>
+<script>
+// Capture the first gesture before module downloads finish. On a phone there
+// may be no second gesture, so an early tap must not disappear during startup.
+globalThis.hijackedStartup = new Promise((resolve) => {
+  const events = ['pointermove', 'pointerdown', 'keydown', 'wheel', 'touchstart', 'click'];
+  function requestLoad() {
+    for (const type of events) removeEventListener(type, requestLoad, true);
+    const shell = document.getElementById('blocker');
+    shell.dataset.screen = 'loading';
+    shell.dataset.determinate = 'false';
+    resolve();
+  }
+  if (new URLSearchParams(location.search).has('autostart')) requestLoad();
+  else for (const type of events) addEventListener(type, requestLoad, { capture: true, passive: true });
+});
+</script>
 <script type="module">
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -1087,6 +1108,7 @@ const WEAPON_CARD_ART = Object.freeze({
   xm8: 'xm8',
 });
 const frontend = new Frontend({
+  waitingForInput: blocker.dataset.screen === 'welcome',
   elements: {
     root: blocker,
     bar: document.getElementById('fe-bar'),
@@ -2422,18 +2444,12 @@ function renderFrame() {
 // plays all time against 125 GB of bandwidth in the first two days of
 // September. A visit that never starts a match now costs ~2.6 MB, not ~47 MB.
 //
-// Any of these events means someone is on the other end, and a person emits one
-// within a second or so of arriving, so the load still overlaps with reading the
-// title screen. A headless crawler emits none of them.
-const BOOT_EVENTS = ['pointermove', 'pointerdown', 'keydown', 'wheel', 'touchstart'];
-function boot() {
-  for (const type of BOOT_EVENTS) removeEventListener(type, boot);
+// The welcome screen asks for input, and the early script above remembers it
+// even while modules are still downloading. Resolve once across all input types.
+globalThis.hijackedStartup.then(() => {
+  frontend.startLoading();
   start();
-}
-// `browser-smoke.mjs` and `ai-game.mjs` drive the page without ever moving a
-// pointer, so they opt back into loading on sight.
-if (new URLSearchParams(location.search).has('autostart')) boot();
-else for (const type of BOOT_EVENTS) addEventListener(type, boot, { passive: true });
+});
 tick();
 
 addEventListener('resize', () => {

--- a/export/web/touch-controls.css
+++ b/export/web/touch-controls.css
@@ -67,6 +67,7 @@ body.touch-mode .fe-content { margin: auto; gap: 16px; flex-shrink: 0; }
 body.touch-mode .fe-btn { min-height: 44px; height: auto; line-height: 44px; touch-action: manipulation; }
 body.touch-mode .fe-class { max-height: none; }
 body.touch-mode .fe-class-grid { overflow: visible; }
+body.touch-mode #blocker[data-screen="welcome"] .touch-settings,
 body.touch-mode #blocker[data-screen="loading"] .touch-settings,
 body.touch-mode #blocker[data-screen="class"] .touch-settings,
 body.touch-mode #blocker[data-screen="error"] .touch-settings { display: none; }

--- a/export/web/touch-controls.css
+++ b/export/web/touch-controls.css
@@ -56,6 +56,7 @@ body.touch-mode canvas { touch-action: none; }
 .touch-settings { width: min(360px, 90vw); font-size: 12px; }
 .touch-settings label { display: flex; align-items: center; gap: 12px; }
 .touch-settings input { flex: 1; min-width: 80px; min-height: 44px; accent-color: var(--fe-accent); }
+.touch-settings select { flex: 1; min-width: 0; min-height: 44px; margin-left: auto; padding: 0 10px; border: 1px solid #b7dec955; border-radius: 5px; background: #14252e; color: #edf9f5; font: inherit; font-size: 16px; touch-action: manipulation; }
 .touch-settings output { min-width: 32px; }
 .touch-settings p { margin: 4px 0; color: #cddfe7a8; }
 body.touch-mode #blocker {

--- a/export/web/touch-controls.css
+++ b/export/web/touch-controls.css
@@ -1,0 +1,114 @@
+#touch-controls[hidden], .touch-only { display: none; }
+body.touch-mode .touch-only { display: block; }
+body.touch-mode .touch-only[hidden] { display: none; }
+body.touch-mode { overscroll-behavior: none; -webkit-user-select: none; user-select: none; }
+body.touch-mode canvas { touch-action: none; }
+#touch-controls {
+  --touch-size: 56px;
+  --touch-left: max(18px, env(safe-area-inset-left));
+  --touch-right: max(18px, env(safe-area-inset-right));
+  --touch-bottom: max(18px, env(safe-area-inset-bottom));
+  position: fixed; inset: 0; z-index: 3; pointer-events: none;
+  color: #eaf9f2; font: 600 10px/1 var(--fe-ui); letter-spacing: .08em;
+  -webkit-touch-callout: none;
+}
+#touch-controls [data-touch], #touch-controls button { touch-action: none; pointer-events: auto; }
+#touch-controls.touch-disabled [data-touch] { pointer-events: none; opacity: .35; }
+.touch-look { position: absolute; inset: 0 0 0 44%; }
+.touch-move { position: absolute; left: var(--touch-left); bottom: var(--touch-bottom); width: 40%; height: 55%; }
+.touch-stick {
+  position: absolute; left: 92px; bottom: 12px; width: 136px; height: 136px;
+  margin-left: -68px; border: 1px solid #d9f8ec55; border-radius: 50%;
+  background: radial-gradient(circle, #b7f9d909 46%, #b7f9d915 47%, #b7f9d903 69%);
+  box-shadow: inset 0 0 18px #0003; pointer-events: none;
+}
+.touch-stick[style*="top:"] { margin-top: -68px; }
+.touch-stick span { position: absolute; bottom: -17px; width: 100%; text-align: center; color: #d6ebe5ad; font-size: 9px; }
+.touch-stick::before { content: '⌃'; position: absolute; top: -18px; width: 100%; text-align: center; color: #b8eed7a8; font-size: 22px; }
+.touch-knob {
+  position: absolute; left: 44px; top: 44px; width: 46px; height: 46px;
+  border: 1px solid #e0fff599; border-radius: 50%; background: #ccf7e426; box-shadow: 0 3px 12px #0004;
+}
+.touch-stick.engaged { border-color: #e0fff5a6; }
+.touch-stick.sprinting { border-color: var(--fe-accent); box-shadow: 0 0 12px #7fffc422; }
+.touch-stick.sprinting span { color: var(--fe-accent); }
+.touch-button {
+  position: absolute; width: var(--touch-size); height: var(--touch-size);
+  display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 5px;
+  border-radius: 50%; border: 1px solid #dbf5ec66; background: #06131b70;
+  color: #edf9f5; font: inherit; text-shadow: 0 1px 4px #000;
+  -webkit-tap-highlight-color: transparent; padding: 0;
+}
+.touch-button svg { width: 23px; height: 23px; fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; pointer-events: none; }
+.touch-button span { pointer-events: none; font-size: 9px; }
+.touch-button.pressed, .touch-button:active { border-color: var(--fe-accent); color: var(--fe-accent); background: #24533cd9; }
+.touch-button:focus-visible { outline: 2px solid var(--fe-accent); outline-offset: 4px; }
+.touch-fire { width: 82px; height: 82px; right: calc(var(--touch-right) + 69px); bottom: calc(var(--touch-bottom) + 76px); border: 2px solid #effff6a6; background: #0b202b66; }
+.touch-fire svg { width: 31px; height: 31px; }
+.touch-aim { right: calc(var(--touch-right) + 167px); bottom: calc(var(--touch-bottom) + 62px); }
+.touch-jump { right: var(--touch-right); bottom: calc(var(--touch-bottom) + 92px); }
+.touch-crouch { right: calc(var(--touch-right) + 14px); bottom: calc(var(--touch-bottom) + 20px); }
+.touch-reload { right: calc(var(--touch-right) + 94px); bottom: var(--touch-bottom); }
+.touch-pause, .touch-scores { top: max(12px, env(safe-area-inset-top)); width: 46px; height: 46px; border-radius: 12px; }
+.touch-pause { right: var(--touch-right); }
+.touch-scores { right: calc(var(--touch-right) + 56px); }
+.touch-hint { position: absolute; right: calc(var(--touch-right) + 22px); bottom: calc(var(--touch-bottom) + 178px); color: #d6ebe59c; font-size: 9px; text-shadow: 0 1px 5px #000; }
+.touch-settings { width: min(360px, 90vw); font-size: 12px; }
+.touch-settings label { display: flex; align-items: center; gap: 12px; }
+.touch-settings input { flex: 1; min-width: 80px; min-height: 44px; accent-color: var(--fe-accent); }
+.touch-settings output { min-width: 32px; }
+.touch-settings p { margin: 4px 0; color: #cddfe7a8; }
+body.touch-mode #blocker {
+  z-index: 5; overflow-y: auto; overscroll-behavior: contain; touch-action: pan-y;
+  padding: max(16px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) max(16px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
+}
+body.touch-mode #blocker > .fe-layer { position: fixed; }
+body.touch-mode .fe-content { margin: auto; gap: 16px; flex-shrink: 0; }
+body.touch-mode .fe-btn { min-height: 44px; height: auto; line-height: 44px; touch-action: manipulation; }
+body.touch-mode .fe-class { max-height: none; }
+body.touch-mode .fe-class-grid { overflow: visible; }
+body.touch-mode #blocker[data-screen="loading"] .touch-settings,
+body.touch-mode #blocker[data-screen="class"] .touch-settings,
+body.touch-mode #blocker[data-screen="error"] .touch-settings { display: none; }
+body.touch-mode #hud-minimap { top: max(10px, env(safe-area-inset-top)); left: max(10px, env(safe-area-inset-left)); transform: scale(.62); transform-origin: top left; }
+body.touch-mode #hud-compass { display: none; }
+body.touch-mode #hud-ammo { bottom: auto; top: max(72px, calc(env(safe-area-inset-top) + 62px)); right: max(18px, env(safe-area-inset-right)); transform: scale(.72); transform-origin: top right; }
+body.touch-mode #killfeed { top: max(118px, calc(env(safe-area-inset-top) + 110px)); right: max(18px, env(safe-area-inset-right)); width: 240px; font-size: 10px; }
+body.touch-mode #match-status { top: max(14px, env(safe-area-inset-top)); max-width: calc(100% - 270px); font-size: 10px; text-align: center; }
+body.touch-mode #medals { top: 30%; right: 8%; transform: scale(.7); transform-origin: right top; }
+body.touch-mode #death-card { bottom: 40%; max-width: 90vw; font-size: 11px; }
+body.touch-mode #scoreboard { padding: max(12px, env(safe-area-inset-top)) 0 max(12px, env(safe-area-inset-bottom)); overflow-y: auto; }
+body.touch-mode .scoreboard-panel { padding: 14px; max-height: 100%; overflow-y: auto; }
+body.touch-mode .scoreboard-row { grid-template-columns: 22px 1fr 42px 48px; gap: 6px; padding: 5px; font-size: 12px; }
+body.touch-mode #match-result { font-size: 13px; }
+body.touch-mode .scoreboard-panel .fe-btn { display: block; margin: 10px auto 0; background: #234d3b; width: min(258px, 100%); }
+body.touch-mode #scoreboard .touch-only[hidden] { display: none; }
+@media (max-height: 500px) {
+  body.touch-mode .fe-content { gap: 10px; }
+  body.touch-mode .fe-wordmark { font-size: 25px; }
+  body.touch-mode .fe-wordmark::after { margin-top: 10px; }
+  body.touch-mode .fe-sub, body.touch-mode .fe-card { display: none; }
+  body.touch-mode #blocker .fe-start, body.touch-mode #blocker .fe-pause { gap: 10px; }
+  body.touch-mode .fe-controls { font-size: 10px; line-height: 1.5; }
+  body.touch-mode #blocker[data-screen="pause"] .fe-buttons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+  body.touch-mode #blocker[data-screen="pause"] .fe-btn { width: min(230px, 40vw); }
+  body.touch-mode #blocker[data-screen="pause"] .fe-controls,
+  body.touch-mode #blocker[data-screen="pause"] .touch-settings p { display: none; }
+  body.touch-mode .fe-class-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  body.touch-mode .fe-class-card { grid-template-columns: 1fr; }
+  body.touch-mode .fe-class-art { height: 55px; }
+  body.touch-mode #killfeed { width: 190px; }
+}
+@media (orientation: portrait) {
+  #touch-controls { --touch-left: max(8px, env(safe-area-inset-left)); --touch-right: max(10px, env(safe-area-inset-right)); --touch-size: 50px; }
+  .touch-stick { left: 70px; bottom: 30px; }
+  .touch-move { height: 38%; width: 42%; }
+  .touch-aim { right: calc(var(--touch-right) + 130px); bottom: calc(var(--touch-bottom) + 152px); }
+  .touch-fire { right: calc(var(--touch-right) + 43px); bottom: calc(var(--touch-bottom) + 88px); width: 76px; height: 76px; }
+  .touch-jump { bottom: calc(var(--touch-bottom) + 185px); }
+  .touch-crouch { right: var(--touch-right); bottom: calc(var(--touch-bottom) + 18px); }
+  .touch-reload { right: calc(var(--touch-right) + 74px); }
+  .touch-hint { right: 14px; bottom: calc(var(--touch-bottom) + 253px); }
+  body.touch-mode #match-status { top: max(128px, calc(env(safe-area-inset-top) + 118px)); max-width: 90%; }
+  body.touch-mode #killfeed { top: 165px; }
+}

--- a/export/web/touch-controls.js
+++ b/export/web/touch-controls.js
@@ -1,0 +1,203 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+// Pointer ownership is independent of DOM hit testing. A finger keeps its job
+// until released, even when it crosses another control or leaves the screen.
+export class TouchInput {
+  constructor({ onLook = () => {}, onAction = () => {} } = {}) {
+    this.onLook = onLook;
+    this.onAction = onAction;
+    this.pointers = new Map();
+    this.reset();
+  }
+
+  reset() {
+    this.pointers.clear();
+    this.forward = this.strafe = this.stickX = this.stickY = 0;
+    this.sprint = this.aim = this.crouch = this.fire = false;
+    this.jumpQueued = this.fireQueued = false;
+  }
+
+  begin(id, kind, x, y, radius = 50) {
+    if (this.pointers.has(id) || [...this.pointers.values()].some(p => p.kind === kind)) return false;
+    this.pointers.set(id, { kind, x, y, originX: x, originY: y, radius });
+    if (kind === 'fire') this.fire = this.fireQueued = true;
+    if (kind === 'jump') this.jumpQueued = true;
+    if (kind === 'aim') this.aim = !this.aim;
+    if (kind === 'crouch') this.crouch = !this.crouch;
+    if (kind === 'reload') this.onAction(kind);
+    return true;
+  }
+
+  move(id, x, y) {
+    const p = this.pointers.get(id);
+    if (!p) return;
+    if (p.kind === 'move') {
+      const dx = (x - p.originX) / p.radius;
+      const dy = (y - p.originY) / p.radius;
+      const length = Math.hypot(dx, dy);
+      const magnitude = clamp((length - 0.12) / 0.88, 0, 1);
+      this.strafe = length ? dx / length * magnitude : 0;
+      this.forward = length ? -dy / length * magnitude : 0;
+      this.stickX = dx / Math.max(1, length) * p.radius;
+      this.stickY = dy / Math.max(1, length) * p.radius;
+      // Hysteresis prevents sprint chatter around the outer ring. Sideways
+      // and backwards movement remain a walk; aiming/firing override sprint.
+      this.sprint = this.forward > (this.sprint ? 0.72 : 0.92);
+    } else if (p.kind === 'look' || p.kind === 'fire') {
+      // With two aiming fingers down, fire owns the camera to avoid doubling
+      // the turn. Track both positions so releasing fire cannot cause a jump.
+      if (p.kind === 'fire' || !this.fire) this.onLook(x - p.x, y - p.y);
+    }
+    p.x = x;
+    p.y = y;
+  }
+
+  end(id, cancelled = false) {
+    const p = this.pointers.get(id);
+    if (!p) return;
+    this.pointers.delete(id);
+    if (p.kind === 'move') {
+      this.forward = this.strafe = this.stickX = this.stickY = 0;
+      this.sprint = false;
+    }
+    if (p.kind === 'fire') {
+      this.fire = false;
+      if (cancelled) this.fireQueued = false;
+    }
+    if (cancelled && p.kind === 'jump') this.jumpQueued = false;
+  }
+
+  read() {
+    const fire = this.fire || this.fireQueued;
+    const input = {
+      forward: this.forward, strafe: this.strafe,
+      sprint: this.sprint && !this.aim && !fire && !this.crouch,
+      crouch: this.crouch, aim: this.aim, fire, jump: this.jumpQueued,
+    };
+    this.fireQueued = this.jumpQueued = false;
+    return input;
+  }
+
+  getState() {
+    return {
+      pointers: this.pointers.size, forward: this.forward, strafe: this.strafe,
+      sprint: this.sprint && !this.aim && !this.fire && !this.crouch,
+      aim: this.aim, crouch: this.crouch, fire: this.fire,
+    };
+  }
+}
+
+export class TouchControls {
+  constructor({ root, onLook, onAction, onModeChange = () => {} }) {
+    this.root = root;
+    this.enabled = false;
+    this.visible = false;
+    this.mode = matchMedia('(pointer: coarse)').matches;
+    this.sensitivity = 1;
+    try {
+      const saved = Number(localStorage.getItem('hijacked.touchSensitivity'));
+      if (saved > 0) this.sensitivity = clamp(saved, 0.4, 2);
+    } catch { /* Storage is optional in private browsing and embedded games. */ }
+    this.input = new TouchInput({
+      onLook: (x, y) => onLook(x, y, this.sensitivity), onAction,
+    });
+    this.stick = root.querySelector('.touch-stick');
+    this.knob = root.querySelector('.touch-knob');
+    this.moveZone = root.querySelector('[data-touch="move"]');
+    this.captures = new Map();
+    const activate = (event) => {
+      if (event.pointerType !== 'touch' || this.mode) return;
+      this.mode = true;
+      document.body.classList.add('touch-mode');
+      onModeChange();
+    };
+    document.body.classList.toggle('touch-mode', this.mode);
+    document.addEventListener('pointerdown', activate, { capture: true, passive: true });
+    root.addEventListener('pointerdown', (event) => {
+      const target = event.target.closest('[data-touch]');
+      if (!this.enabled || event.pointerType !== 'touch' || !target) return;
+      event.preventDefault();
+      const kind = target.dataset.touch;
+      const radius = this.stick.offsetWidth * 0.36;
+      if (!this.input.begin(event.pointerId, kind, event.clientX, event.clientY, radius)) return;
+      target.setPointerCapture(event.pointerId);
+      this.captures.set(event.pointerId, target);
+      if (kind === 'move') {
+        const bounds = this.moveZone.getBoundingClientRect();
+        this.stick.style.left = `${event.clientX - bounds.left}px`;
+        this.stick.style.top = `${event.clientY - bounds.top}px`;
+        this.stick.style.bottom = 'auto';
+      }
+      this.render();
+    });
+    root.addEventListener('pointermove', (event) => {
+      if (!this.input.pointers.has(event.pointerId)) return;
+      event.preventDefault();
+      this.input.move(event.pointerId, event.clientX, event.clientY);
+      this.render();
+    });
+    for (const type of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+      root.addEventListener(type, (event) => {
+        this.input.end(event.pointerId, type !== 'pointerup');
+        this.captures.delete(event.pointerId);
+        this.render();
+      });
+    }
+    root.addEventListener('contextmenu', event => event.preventDefault());
+    // Rotation/browser chrome changes invalidate the stick origin and pointer
+    // coordinates. Never carry movement or a held trigger into a new layout.
+    addEventListener('resize', () => this.reset());
+    globalThis.visualViewport?.addEventListener('resize', () => this.reset());
+  }
+
+  setSensitivity(value) {
+    if (!Number.isFinite(Number(value))) return;
+    this.sensitivity = clamp(Number(value), 0.4, 2);
+    try { localStorage.setItem('hijacked.touchSensitivity', String(this.sensitivity)); } catch {}
+  }
+
+  setEnabled(enabled, visible = enabled) {
+    enabled = Boolean(enabled && this.mode);
+    visible = Boolean(visible && this.mode);
+    if (this.enabled && !enabled) this.reset();
+    this.enabled = enabled;
+    if (this.visible !== visible) {
+      this.visible = visible;
+      this.root.hidden = !visible;
+    }
+    this.root.classList.toggle('touch-disabled', !enabled);
+  }
+
+  reset() {
+    this.input.reset();
+    for (const [id, target] of this.captures) {
+      if (target.hasPointerCapture(id)) target.releasePointerCapture(id);
+    }
+    this.captures.clear();
+    this.render();
+  }
+
+  render() {
+    const state = this.input.getState();
+    this.knob.style.transform = `translate(${this.input.stickX}px, ${this.input.stickY}px)`;
+    const moving = [...this.input.pointers.values()].some(p => p.kind === 'move');
+    if (!moving) {
+      this.stick.style.left = this.stick.style.top = this.stick.style.bottom = '';
+    }
+    this.stick.classList.toggle('engaged', moving);
+    this.stick.classList.toggle('sprinting', state.sprint);
+    this.stick.querySelector('span').textContent = state.sprint ? 'SPRINT' : 'MOVE';
+    for (const button of this.root.querySelectorAll('button[data-touch]')) {
+      const kind = button.dataset.touch;
+      const pressed = kind === 'aim' || kind === 'crouch' ? state[kind]
+        : [...this.input.pointers.values()].some(p => p.kind === kind);
+      button.classList.toggle('pressed', pressed);
+      if (kind === 'aim' || kind === 'crouch') button.setAttribute('aria-pressed', String(pressed));
+    }
+  }
+
+  getState() {
+    return { mode: this.mode, enabled: this.enabled, visible: this.visible,
+      sensitivity: this.sensitivity, ...this.input.getState() };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ai:test": "node .tools/ai-game.mjs test",
     "ai:enemy": "node .tools/ai-game.mjs enemy-test",
     "ai:life": "node .tools/ai-game.mjs life-test",
+    "ai:mobile": "node .tools/ai-game.mjs mobile-test",
     "ai:record": "node .tools/ai-game.mjs record",
     "bake:map": "node .tools/bake_map.mjs",
     "bake:collision": "node .tools/bake_collision_bvh.mjs",
@@ -22,7 +23,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/touch-controls.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ai:enemy": "node .tools/ai-game.mjs enemy-test",
     "ai:life": "node .tools/ai-game.mjs life-test",
     "ai:mobile": "node .tools/ai-game.mjs mobile-test",
+    "ai:graphics": "node .tools/ai-game.mjs graphics-test",
     "ai:record": "node .tools/ai-game.mjs record",
     "bake:map": "node .tools/bake_map.mjs",
     "bake:collision": "node .tools/bake_collision_bvh.mjs",
@@ -23,7 +24,7 @@
     "bake:probes": "node .tools/bake_probes.mjs",
     "perf:probe": "node .tools/perf_probe.mjs",
     "test": "node --test",
-    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/touch-controls.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
+    "test:unit": "node --test test/cloudflare-play-counter.test.mjs test/collision-world.test.mjs test/scene-optimizer.test.mjs test/player-controller.test.mjs test/touch-controls.test.mjs test/graphics-settings.test.mjs test/player-health.test.mjs test/weapon-controller.test.mjs test/viewmodel-ads.test.mjs test/viewmodel-camo.test.mjs test/view-bob.test.mjs test/hud.test.mjs test/free-for-all-match.test.mjs test/medals.test.mjs test/play-counter.test.mjs test/enemy-tactics.test.mjs test/frontend.test.mjs test/t6-sab-audio.test.mjs test/weapon-audio.test.mjs test/weapon-audio-manifest.test.mjs test/xanim-to-json.test.mjs test/notetracks.test.mjs test/web-textures.test.mjs test/lighting.test.mjs test/light-probes.test.mjs tests/navmesh-bake.test.mjs",
     "test:browser": "node --test test/browser-smoke.mjs"
   },
   "repository": {

--- a/test/frontend.test.mjs
+++ b/test/frontend.test.mjs
@@ -2,6 +2,23 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { Frontend, SCREENS } from '../export/web/frontend.js';
 
+test('a deferred load shows welcome until requested, without allowing play', () => {
+  const frontend = new Frontend({ waitingForInput: true });
+  frontend.expect({ map: 1 });
+  assert.equal(frontend.getState().screen, 'welcome');
+  assert.equal(frontend.getState().caption, '');
+  assert.equal(frontend.play(), false);
+  assert.equal(frontend.startLoading(), true);
+  assert.equal(frontend.getState().screen, 'loading');
+  assert.equal(frontend.getState().caption, 'map geometry');
+  assert.equal(frontend.startLoading(), false, 'repeated input cannot restart loading');
+  frontend.setReady();
+  assert.equal(frontend.startLoading(), false, 'late input cannot reopen loading');
+  assert.equal(frontend.play(), true);
+  frontend.fail('Failed to load');
+  assert.equal(frontend.startLoading(), false, 'input cannot erase an error');
+});
+
 test('frontend exposes the class screen and keeps its selected rifle across routes', () => {
   const selected = [];
   const frontend = new Frontend({

--- a/test/graphics-settings.test.mjs
+++ b/test/graphics-settings.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as THREE from 'three';
+import { GraphicsSettings, chooseSamples, filterTextures } from '../export/web/graphics-settings.js';
+
+test('mobile presets respect density, pixel budgets, and GPU size limits', () => {
+  const settings = new GraphicsSettings({ mobile: true });
+  settings.setViewport(844, 390, 3);
+  assert.equal(settings.pixelRatio, 1.5);
+  assert.equal(settings.antialias, true);
+  settings.setPreset('quality');
+  assert.equal(settings.pixelRatio, 2);
+  settings.setViewport(2048, 1536, 3);
+  assert.ok(2048 * 1536 * settings.pixelRatio ** 2 <= 1800001);
+  settings.setViewport(844, 390, 3, 512);
+  assert.ok(844 * settings.pixelRatio <= 512);
+  settings.setViewport(390, 844, 1);
+  assert.equal(settings.pixelRatio, 1);
+  settings.setPreset('performance');
+  assert.equal(settings.antialias, false);
+});
+
+test('desktop keeps its rendering budget and invalid saved presets use Auto', () => {
+  const settings = new GraphicsSettings({ preset: 'broken' });
+  settings.setViewport(1280, 720, 3);
+  assert.equal(settings.preset, 'auto');
+  assert.equal(settings.pixelRatio, 1);
+  assert.equal(settings.antialias, false);
+  assert.equal(settings.setPreset('__proto__'), false);
+  settings.setViewport(3840, 2160, 3);
+  assert.ok(3840 * 2160 * settings.pixelRatio ** 2 <= 1440001);
+});
+
+function frames(settings, count, dt, from = 0) {
+  let time = from;
+  for (let i = 0; i < count; i++) settings.observeFrame(time += dt, true);
+  return time;
+}
+
+test('Auto backs off sustained slow frames and recovers cautiously', () => {
+  const settings = new GraphicsSettings({ mobile: true });
+  settings.setViewport(844, 390, 3);
+  let time = frames(settings, 160, 33);
+  assert.ok(settings.pixelRatio < 1.5 && settings.pixelRatio >= 0.75);
+  const slow = settings.pixelRatio;
+  time = frames(settings, 180, 16.67, time);
+  assert.equal(settings.pixelRatio, slow, 'three fast seconds cannot immediately raise resolution');
+  frames(settings, 900, 16.67, time);
+  assert.ok(settings.pixelRatio > slow && settings.pixelRatio <= 1.5);
+});
+
+test('pause, long stalls, and manual presets cannot contaminate Auto timing', () => {
+  const settings = new GraphicsSettings({ mobile: true });
+  settings.setViewport(844, 390, 3);
+  let time = frames(settings, 40, 33);
+  settings.observeFrame(time += 5000, false);
+  settings.observeFrame(time += 5000, true);
+  settings.observeFrame(time += 5000, true);
+  time = frames(settings, 80, 16.67, time);
+  assert.equal(settings.pixelRatio, 1.5);
+  settings.setPreset('quality');
+  frames(settings, 300, 50, time);
+  assert.equal(settings.pixelRatio, 2);
+});
+
+test('Auto lowers the effective tablet resolution and never exceeds its floor', () => {
+  const settings = new GraphicsSettings({ mobile: true });
+  settings.setViewport(1600, 900, 3);
+  const start = settings.pixelRatio;
+  frames(settings, 300, 50);
+  assert.ok(settings.pixelRatio < start);
+  assert.equal(settings.pixelRatio, 0.75);
+  settings.setViewport(900, 1600, 3);
+  assert.equal(settings.pixelRatio, 0.75, 'rotation preserves learned quality');
+});
+
+test('Auto can recover a severely overloaded phone instead of treating every frame as a pause', () => {
+  const settings = new GraphicsSettings({ mobile: true });
+  settings.setViewport(844, 390, 3);
+  frames(settings, 40, 500);
+  assert.equal(settings.pixelRatio, 0.75);
+});
+
+test('MSAA requires a sample count shared by HDR color and depth', () => {
+  assert.equal(chooseSamples([8, 4, 2], [4, 2]), 2);
+  assert.equal(chooseSamples(new Int32Array([4]), new Int32Array([4, 2])), 4);
+  assert.equal(chooseSamples([4], [2]), 0);
+  assert.equal(chooseSamples([], [4]), 0);
+  assert.equal(chooseSamples([8], [8]), 0);
+});
+
+test('filtering updates shared surface textures once and leaves lookup textures alone', () => {
+  const scene = new THREE.Scene();
+  const map = new THREE.Texture(), normalMap = new THREE.Texture(), envMap = new THREE.Texture();
+  const material = new THREE.MeshStandardMaterial({ map, normalMap, envMap });
+  scene.add(new THREE.Mesh(new THREE.PlaneGeometry(), material), new THREE.Mesh(new THREE.PlaneGeometry(), material));
+  assert.equal(filterTextures(scene, 8, 4), 2);
+  assert.equal(map.anisotropy, 4);
+  assert.equal(normalMap.anisotropy, 4);
+  assert.equal(envMap.anisotropy, 1);
+  const version = map.version;
+  filterTextures(scene, 8, 4);
+  assert.equal(map.version, version, 'unchanged filtering must not re-upload textures');
+  filterTextures(scene, 2, 4);
+  assert.equal(map.anisotropy, 2);
+  assert.equal(map.version, version + 1);
+});

--- a/test/touch-controls.test.mjs
+++ b/test/touch-controls.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { TouchInput } from '../export/web/touch-controls.js';
+
+test('stick has a dead zone, proportional walking, and a circular speed limit', () => {
+  const input = new TouchInput();
+  input.begin(1, 'move', 100, 100);
+  input.move(1, 103, 98);
+  assert.equal(input.read().forward, 0);
+  input.move(1, 100, 75);
+  assert.ok(input.read().forward > 0.4 && input.read().forward < 0.5);
+  input.move(1, 200, 0);
+  const diagonal = input.read();
+  assert.ok(Math.abs(Math.hypot(diagonal.forward, diagonal.strafe) - 1) < 1e-10);
+  assert.equal(diagonal.sprint, false);
+  input.end(1);
+  assert.equal(input.read().forward, 0);
+  assert.equal(input.read().strafe, 0);
+});
+
+test('movement, looking, and firing are owned by separate fingers', () => {
+  const turns = [];
+  const input = new TouchInput({ onLook: (...delta) => turns.push(delta) });
+  input.begin(1, 'move', 0, 0);
+  input.move(1, 0, -50);
+  assert.equal(input.begin(2, 'move', 20, 20), false);
+  input.begin(2, 'look', 200, 100);
+  input.move(2, 225, 90);
+  input.begin(3, 'fire', 300, 150);
+  input.move(3, 325, 150);
+  input.move(2, 250, 90); // Fire owns aim while both right-side fingers move.
+  assert.deepEqual(turns, [[25, -10], [25, 0]]);
+  assert.equal(input.read().forward, 1);
+  assert.equal(input.read().fire, true);
+  input.end(3);
+  input.move(2, 252, 90);
+  assert.deepEqual(turns.at(-1), [2, 0]);
+  assert.equal(input.read().fire, false);
+  assert.equal(input.read().forward, 1);
+});
+
+test('sprint uses hysteresis and yields immediately to aim, crouch, or fire', () => {
+  const input = new TouchInput();
+  input.begin(1, 'move', 0, 0);
+  input.move(1, 0, -50);
+  assert.equal(input.read().sprint, true);
+  input.move(1, 0, -42);
+  assert.equal(input.read().sprint, true);
+  for (const action of ['aim', 'crouch', 'fire']) {
+    input.begin(2, action, 0, 0);
+    assert.equal(input.read().sprint, false, action);
+    input.end(2);
+    if (action !== 'fire') { input.begin(2, action, 0, 0); input.end(2); }
+    assert.equal(input.read().sprint, true);
+  }
+  input.move(1, 0, 50);
+  assert.equal(input.read().sprint, false);
+});
+
+test('quick fire and jump taps survive until one simulation frame', () => {
+  const input = new TouchInput();
+  for (const kind of ['fire', 'jump']) {
+    input.begin(1, kind, 0, 0);
+    input.end(1);
+    assert.equal(input.read()[kind], true);
+    assert.equal(input.read()[kind], false);
+  }
+});
+
+test('cancellation discards pending actions and reset clears every owned input', () => {
+  const input = new TouchInput();
+  input.begin(1, 'fire', 0, 0);
+  input.end(1, true);
+  assert.equal(input.read().fire, false);
+  input.begin(1, 'jump', 0, 0);
+  input.end(1, true);
+  assert.equal(input.read().jump, false);
+  input.begin(1, 'move', 0, 0);
+  input.move(1, 50, -50);
+  input.begin(2, 'fire', 0, 0);
+  input.begin(3, 'aim', 0, 0);
+  input.begin(4, 'crouch', 0, 0);
+  input.reset();
+  input.move(1, 500, 500); // Stale events after rotation or pause have no effect.
+  assert.deepEqual(input.read(), { forward: 0, strafe: 0, sprint: false, crouch: false, aim: false, fire: false, jump: false });
+  assert.equal(input.getState().pointers, 0);
+});
+
+test('reload is invoked once per pointer press', () => {
+  let reloads = 0;
+  const input = new TouchInput({ onAction: () => reloads++ });
+  input.begin(1, 'reload', 0, 0);
+  input.begin(1, 'reload', 0, 0);
+  input.move(1, 200, 200);
+  assert.equal(reloads, 1);
+  input.end(1);
+  input.begin(1, 'reload', 0, 0);
+  assert.equal(reloads, 2);
+});


### PR DESCRIPTION
## Summary

Phones and tablets previously depended on mouse pointer lock and keyboard input to play. Add touch deployment, analog movement with push-to-sprint, swipe aiming, drag-to-aim firing, and jump, reload, aim, and crouch controls. Make pause, scores, class selection, and restart reachable by touch, with responsive menus, safe-area spacing, saved sensitivity, and optional full screen.

Replace the misleading "Map geometry… 0%" screen before the first interaction with a visible load button. Remember taps received while modules are downloading and start the map download once. Clear held input across cancellation, rotation, interruptions, death, and respawn; prevent the pause gesture from clicking through and resuming.

Add saved Auto, Performance, and Quality graphics presets. Auto starts at up to 1.5× resolution and adjusts gradually to sustained frame times; Quality allows up to 2×. Cap resolution by pixel budget and GPU limits, add capability-limited texture filtering, and smooth the actual HDR scene/weapon target with supported MSAA or an FXAA fallback. Preserve touch capture when resolution changes, and stop rendering the covered scene behind menus.

## Verification

- [x] `npm run test:unit` — 181 tests passed.
- [x] `npm run ai:test` — desktop movement and firing smoke checks passed.
- [x] `npm run ai:mobile` — 38 cold-start and mobile gameplay checks passed.
- [x] `npm run ai:graphics` — 19 checks passed for presets, rendering buffers, filtering, persistence, rotation, and held touch input.
- [x] `npm run ai:graphics -- fallback` — 20 checks passed with HDR multisampling unavailable.
- [x] `AI_GAME_MOBILE=1 npm run ai:record -- 10 m27` — captured and inspected mobile gameplay motion.
- [x] I inspected structured state, console output, and rendered screenshots/trace frames, including Performance versus Quality comparisons.
- [x] Verified the [new Pages preview](https://bf596445.claude-of-duty-bfq.pages.dev/) with real browser touch events: an early load tap survives delayed scripts, the map downloads once, Quality applies from the title menu, and deployment/pause/portrait play work without pointer lock or browser errors.

CI unit tests and Cloudflare Pages deployment pass for `80943d9`. The separate `Workers Builds: hijacked-web-viewer` integration fails on this commit and on `main`.

Browser coverage uses Chromium touch emulation and software rendering. It verifies behavior and visuals; physical iOS/Android frame rates and battery use have not been measured. Generated screenshots, recordings, and traces remain local and are excluded from the PR.

## Rights and scope

- [x] This change is focused and does not contain unrelated generated files.
- [x] I have the right to submit everything in this change.
- [x] I agree to license my contribution under the repository's MIT license.
- [x] I have not added secrets, personal data, or unlicensed third-party assets.
